### PR TITLE
New entry button

### DIFF
--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/search/SearchAppSearchBar.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/search/SearchAppSearchBar.jsx
@@ -1,0 +1,34 @@
+import React, { useContext } from "react";
+import { Grid, Button, Container } from "semantic-ui-react";
+import {
+  SearchBar,
+  SearchConfigurationContext,
+} from "@js/invenio_search_ui/components";
+import { buildUID } from "react-searchkit";
+
+//
+export const SearchAppSearchBar = () => {
+  const config = useContext(SearchConfigurationContext);
+  const newEntryUrl = config.searchApi.axios.url.replace("/api", "") + "/_new";
+  return (
+    <Container className="mt-20">
+      <Grid>
+        <Grid.Column mobile={16} tablet={16} computer={10}>
+          <SearchBar elementId="" buildUID={buildUID} />
+        </Grid.Column>
+        <Grid.Column floated="right" mobile={16} tablet={16} computer={4}>
+          <Button
+            as="a"
+            href={newEntryUrl}
+            fluid
+            color="green"
+            icon="plus"
+            labelPosition="left"
+            content="New Entry"
+            type="button"
+          />
+        </Grid.Column>
+      </Grid>
+    </Container>
+  );
+};

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/search/SearchAppSearchbarContainer.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/search/SearchAppSearchbarContainer.jsx
@@ -1,18 +1,17 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Overridable from "react-overridable";
-
 import { SearchBar } from "@js/invenio_search_ui/components";
 import { buildUID } from "react-searchkit";
 
 export const SearchAppSearchbarContainer = ({ appName }) => {
+  console.log("searcdadadah bar");
   return (
     <Overridable id={buildUID("SearchApp.searchbar", "", appName)}>
-      <SearchBar buildUID={buildUID} />
+      <SearchBar elementId="" buildUID={buildUID} />
     </Overridable>
   );
 };
-
 SearchAppSearchbarContainer.propTypes = {
   appName: PropTypes.string.isRequired,
 };

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/search/index.js
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/search/index.js
@@ -14,3 +14,4 @@ export { SearchAppSort } from "./SearchAppSort";
 export { SearchFiltersToggleElement } from "./SearchFiltersToggleElement";
 export { SearchAppResults } from "./SearchAppResults";
 export { EmptyResultsElement } from "./EmptyResultsElement";
+export { SearchAppSearchBar } from "./SearchAppSearchBar";


### PR DESCRIPTION
The idea is to have the buttons on the sidebar accross all pages (both jinja and react), however, when working with invenio's search app, this turns out a bit complicated to do without actually overriding the entire app. I tried a different approach - by overriding the search bar - not sure if this is what we would like.