### PR TITLE
Provide supported locales in formconfig

### DIFF
--- a/oarepo_ui/resources/config.py
+++ b/oarepo_ui/resources/config.py
@@ -153,6 +153,7 @@ class RecordsUIResourceConfig(UIResourceConfig):
 
         return dict(
             current_locale=str(current_i18n.locale),
+            locales=[{"code": l.language, "name": l.get_display_name()} for l in current_i18n.get_locales()],
             default_locale=conf.get("BABEL_DEFAULT_LOCALE", "en"),
             links=dict(),
             custom_fields=self.custom_fields,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-ui
-version = 5.0.31
+version = 5.0.32
 description = UI module for invenio 3.5+
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Adds `formConfig.locales` configuration with site-wide available locales

![Screenshot 2023-07-21 at 14 22 10](https://github.com/oarepo/oarepo-ui/assets/646743/0ae0fbe5-34d1-435c-abae-c6a70e5c9dfd)

Fixes #48