### PR TITLE
Miroslavsimek/be 135 add jinjax catalogue to oarepo UI component methods

### DIFF
--- a/oarepo_ui/config.py
+++ b/oarepo_ui/config.py
@@ -6,3 +6,5 @@ OAREPO_UI_DEVELOPMENT_MODE = False
 
 # We set this to avoid https://github.com/inveniosoftware/invenio-administration/issues/180
 THEME_HEADER_LOGIN_TEMPLATE = "oarepo_ui/header_login.html"
+
+OAREPO_UI_JINJAX_FILTERS = {}

--- a/oarepo_ui/ext.py
+++ b/oarepo_ui/ext.py
@@ -80,22 +80,6 @@ def list_templates(env):
     return searchpath
 
 
-def catalog_config(catalog, env):
-    context = {}
-    current_app.update_template_context(context)
-    catalog.jinja_env.loader = env.loader
-    context.update(catalog.jinja_env.globals)
-    context.update(env.globals)
-    catalog.jinja_env.globals = context
-    catalog.jinja_env.extensions.update(env.extensions)
-    catalog.jinja_env.filters.update(env.filters)
-
-    env.loader.searchpath = list_templates(env)
-    catalog.prefixes[""] = env.loader
-
-    return catalog
-
-
 class OARepoUIState:
     def __init__(self, app):
         self.app = app
@@ -109,7 +93,23 @@ class OARepoUIState:
     def catalog(self):
         self._catalog = Catalog()
 
-        return catalog_config(self._catalog, self.templates.jinja_env)
+        return self._catalog_config(self._catalog, self.templates.jinja_env)
+
+    def _catalog_config(self, catalog, env):
+        context = {}
+        self.app.update_template_context(context)
+        catalog.jinja_env.loader = env.loader
+        context.update(catalog.jinja_env.globals)
+        context.update(env.globals)
+        catalog.jinja_env.globals = context
+        catalog.jinja_env.extensions.update(env.extensions)
+        catalog.jinja_env.filters.update(env.filters)
+        catalog.jinja_env.filters.update(self.app.config["OAREPO_UI_JINJAX_FILTERS"])
+
+        env.loader.searchpath = list_templates(env)
+        catalog.prefixes[""] = env.loader
+
+        return catalog
 
     def get_template(self, layout: str, blocks: Dict[str, str]):
         return self.templates.get_template(layout, frozendict(blocks))

--- a/oarepo_ui/ext.py
+++ b/oarepo_ui/ext.py
@@ -106,8 +106,8 @@ class OARepoUIState:
         catalog.jinja_env.filters.update(env.filters)
         catalog.jinja_env.filters.update(self.app.config["OAREPO_UI_JINJAX_FILTERS"])
 
-        env.loader.searchpath = list_templates(env)
-        catalog.prefixes[""] = env.loader
+        env.loader.searchpath = list_templates(catalog.jinja_env)
+        catalog.prefixes[""] = catalog.jinja_env.loader
 
         return catalog
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-ui
-version = 5.0.57
+version = 5.0.58
 description = UI module for invenio 3.5+
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-ui
-version = 5.0.56
+version = 5.0.57
 description = UI module for invenio 3.5+
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Decided to move filters to configuration, as catalogue is a singleton and can not be extended by filters later on (shared by multiple threads/requests)