### PR TITLE
fixed components to accept new type of vocabularies

### DIFF
--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/LanguageSelectField/LanguageSelectField.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/LanguageSelectField/LanguageSelectField.jsx
@@ -28,7 +28,7 @@ export const LanguageSelectField = ({
       required={required}
       clearable={clearable}
       multiple={multiple}
-      options={options ?? languages}
+      options={options ?? languages.all}
       label={<FieldLabel htmlFor={fieldPath} icon={labelIcon} label={label} />}
       selectOnBlur={false}
       fluid

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/MultilingualTextInput/MultilingualTextInput.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/MultilingualTextInput/MultilingualTextInput.jsx
@@ -42,7 +42,7 @@ export const MultilingualTextInput = ({
         const fieldPathPrefix = `${fieldPath}.${indexPath}`;
         const availableLanguages = eliminateUsedLanguages(
           indexPath,
-          allLanguages,
+          allLanguages.all,
           array
         );
         return (


### PR DESCRIPTION
@mirekys Minor modification as the vocabulary options are now in vocabularies.vocabularytype.all in form config. I think it might be better to change like this (add .all to components that are using the options), thank to change the useVocabularyOptions hook, because, some other things come inside the vocabularies.vocabularyType and maybe they could be useful for something. Please take a look and let me know. 