### PR TITLE
Stojanovic/fe 117 edtf datepicker issues

### DIFF
--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/EDTFDatePickerField/EDTFDatePickerWrapper.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/EDTFDatePickerField/EDTFDatePickerWrapper.jsx
@@ -13,7 +13,6 @@ export const EDTFDatePickerWrapper = ({
   clearButtonClassName,
   dateEdtfFormat,
   setDateEdtfFormat,
-  handleChange,
   handleClear,
   datePickerProps,
   customInputProps,
@@ -23,9 +22,6 @@ export const EDTFDatePickerWrapper = ({
   return (
     <DatePicker
       locale={i18next.language}
-      onChange={(date) => {
-        handleChange(date);
-      }}
       renderCustomHeader={(props) => (
         <DatePickerHeader
           dateEdtfFormat={dateEdtfFormat}

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/EDTFDatePickerField/EDTFDatePickerWrapper.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/EDTFDatePickerField/EDTFDatePickerWrapper.jsx
@@ -39,7 +39,6 @@ export const EDTFDatePickerWrapper = ({
       autoComplete="off"
       dateFormat={dateFormat}
       clearButtonClassName={clearButtonClassName}
-      showPopperArrow={false}
       customInput={
         <InputElement
           handleClear={handleClear}
@@ -49,6 +48,16 @@ export const EDTFDatePickerWrapper = ({
         />
       }
       placeholderText={placeholder}
+      popperModifiers={[
+        {
+          name: "arrow",
+          options: {
+            padding: ({ popper, reference, placement }) => ({
+              right: Math.min(popper.width, reference.width) - 24,
+            }),
+          },
+        },
+      ]}
       {...datePickerProps}
     />
   );

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/EDTFDatePickerField/EDTFDateRangePickerField.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/EDTFDatePickerField/EDTFDateRangePickerField.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { useField, useFormikContext } from "formik";
 import PropTypes from "prop-types";
-import { FieldLabel, GroupField } from "react-invenio-forms";
+import { FieldLabel } from "react-invenio-forms";
 import { Form, Radio } from "semantic-ui-react";
 import { i18next } from "@translations/oarepo_ui/i18next";
 import {
@@ -20,9 +20,9 @@ export const EDTFDaterangePicker = ({
   helpText,
   required,
   clearButtonClassName,
-  startDateInputPlaceholder,
-  endDateInputPlaceholder,
+  dateRangeInputPlaceholder,
   singleDateInputPlaceholder,
+  datePickerPropsOverrides,
 }) => {
   // TODO: The datepickers shall recieve needed locales from form config (set in Invenio.cfg)
   const { setFieldValue } = useFormikContext();
@@ -56,42 +56,18 @@ export const EDTFDaterangePicker = ({
     }
   };
 
-  const handleStartDateChange = (date) => {
-    dates = [...dates];
-    dates[0] = date;
-    handleChange(dates);
-  };
-
-  const handleEndDateChange = (date) => {
-    dates = [...dates];
-    dates[1] = date;
-    handleChange(dates);
-  };
-
   const handleSingleDateChange = (date) => {
     dates = [...dates];
     dates = [date, date];
     handleChange(dates);
   };
 
-  const handleClearStartDate = () => {
-    dates = [...dates];
-    dates[0] = null;
-    handleChange(dates);
-  };
-  const handleClearEndDate = () => {
-    dates = [...dates];
-    dates[1] = null;
-    handleChange(dates);
-  };
-
-  const handleClearSingleDate = () => {
+  const handleClear = () => {
     dates = [...dates];
     dates = [null, null];
     handleChange(dates);
   };
-  // handle situation if someone selected just one date, when switching to the single input
-  // to fill it with one of the selected values
+
   const handleSingleDatePickerSelection = () => {
     if (!dates[0] && dates[1]) {
       const newDates = [dates[1], dates[1]].map((date) =>
@@ -106,84 +82,57 @@ export const EDTFDaterangePicker = ({
     }
     setShowSingleDatePicker(true);
   };
+
+  const pickerProps = showSingleDatePicker
+    ? {
+        selected: startDate,
+        onChange: handleSingleDateChange,
+      }
+    : {
+        selected: startDate,
+        onChange: handleChange,
+        startDate: startDate,
+        endDate: endDate,
+        selectsRange: true,
+      };
   return (
-    <React.Fragment>
-      <Form.Field className="ui datepicker field mb-0" required={required}>
-        <FieldLabel htmlFor={fieldPath} icon={icon} label={label} />
-        <Form.Field className="mb-0">
-          <Radio
-            label={i18next.t("Date range.")}
-            name="startAndEnd"
-            checked={!showSingleDatePicker}
-            onChange={() => setShowSingleDatePicker(false)}
-            className="rel-mr-1"
-          />
-          <Radio
-            label={i18next.t("Single date.")}
-            name="oneDate"
-            checked={showSingleDatePicker}
-            onChange={() => handleSingleDatePickerSelection()}
-            required={false}
-          />
-        </Form.Field>
-        {showSingleDatePicker ? (
-          <div>
-            <EDTFDatePickerWrapper
-              fieldPath={fieldPath}
-              handleChange={handleSingleDateChange}
-              handleClear={handleClearSingleDate}
-              placeholder={singleDateInputPlaceholder}
-              dateEdtfFormat={dateEdtfFormat}
-              setDateEdtfFormat={setDateEdtfFormat}
-              dateFormat={dateFormat}
-              clearButtonClassName={clearButtonClassName}
-              datePickerProps={{ selected: startDate }}
-              helpText={helpText}
-            />
-          </div>
-        ) : (
-          <GroupField>
-            <EDTFDatePickerWrapper
-              fieldPath={fieldPath}
-              handleChange={handleStartDateChange}
-              handleClear={handleClearStartDate}
-              placeholder={startDateInputPlaceholder}
-              dateEdtfFormat={dateEdtfFormat}
-              setDateEdtfFormat={setDateEdtfFormat}
-              dateFormat={dateFormat}
-              clearButtonClassName={clearButtonClassName}
-              datePickerProps={{
-                selected: startDate,
-                startDate: startDate,
-                endDate: endDate,
-                selectsStart: true,
-                maxDate: endDate ?? undefined,
-              }}
-              customInputProps={{ label: i18next.t("From") }}
-            />
-            <EDTFDatePickerWrapper
-              fieldPath={fieldPath}
-              handleChange={handleEndDateChange}
-              handleClear={handleClearEndDate}
-              placeholder={endDateInputPlaceholder}
-              dateEdtfFormat={dateEdtfFormat}
-              setDateEdtfFormat={setDateEdtfFormat}
-              dateFormat={dateFormat}
-              clearButtonClassName={clearButtonClassName}
-              datePickerProps={{
-                selected: endDate,
-                startDate: startDate,
-                endDate: endDate,
-                selectsEnd: true,
-                minDate: startDate,
-              }}
-              customInputProps={{ label: i18next.t("To") }}
-            />
-          </GroupField>
-        )}
-        <label className="helptext">{helpText}</label>
+    <Form.Field className="ui datepicker field mb-0" required={required}>
+      <FieldLabel htmlFor={fieldPath} icon={icon} label={label} />
+      <Form.Field className="mb-0">
+        <Radio
+          label={i18next.t("Date range.")}
+          name="startAndEnd"
+          checked={!showSingleDatePicker}
+          onChange={() => setShowSingleDatePicker(false)}
+          className="rel-mr-1"
+        />
+        <Radio
+          label={i18next.t("Single date.")}
+          name="oneDate"
+          checked={showSingleDatePicker}
+          onChange={() => handleSingleDatePickerSelection()}
+          required={false}
+        />
       </Form.Field>
-    </React.Fragment>
+      <Form.Field>
+        <EDTFDatePickerWrapper
+          fieldPath={fieldPath}
+          handleClear={handleClear}
+          placeholder={
+            showSingleDatePicker
+              ? singleDateInputPlaceholder
+              : dateRangeInputPlaceholder
+          }
+          dateEdtfFormat={dateEdtfFormat}
+          setDateEdtfFormat={setDateEdtfFormat}
+          dateFormat={dateFormat}
+          clearButtonClassName={clearButtonClassName}
+          datePickerProps={{ ...pickerProps, ...datePickerPropsOverrides }}
+          helpText={helpText}
+        />
+      </Form.Field>
+      <label className="helptext">{helpText}</label>
+    </Form.Field>
   );
 };
 
@@ -194,9 +143,9 @@ EDTFDaterangePicker.propTypes = {
   helpText: PropTypes.string,
   required: PropTypes.bool,
   clearButtonClassName: PropTypes.string,
-  startDateInputPlaceholder: PropTypes.string,
-  endDateInputPlaceholder: PropTypes.string,
   singleDateInputPlaceholder: PropTypes.string,
+  dateRangeInputPlaceholder: PropTypes.string,
+  datePickerPropsOverrides: PropTypes.object,
 };
 
 EDTFDaterangePicker.defaultProps = {
@@ -206,7 +155,6 @@ EDTFDaterangePicker.defaultProps = {
   ),
   required: false,
   clearButtonClassName: "clear-icon",
-  startDateInputPlaceholder: i18next.t("Starting date"),
-  endDateInputPlaceholder: i18next.t("Ending date"),
-  singleDateInputPlaceholder: i18next.t("Choose one date"),
+  singleDateInputPlaceholder: i18next.t("Choose one date."),
+  dateRangeInputPlaceholder: i18next.t("Choose date range (From - To)."),
 };

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/EDTFDatePickerField/EDTFDateRangePickerField.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/EDTFDatePickerField/EDTFDateRangePickerField.jsx
@@ -181,8 +181,8 @@ export const EDTFDaterangePicker = ({
             />
           </GroupField>
         )}
+        <label className="helptext">{helpText}</label>
       </Form.Field>
-      <label className="helptext">{helpText}</label>
     </React.Fragment>
   );
 };

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/EDTFDatePickerField/EDTFSingleDatePickerField.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/EDTFDatePickerField/EDTFSingleDatePickerField.jsx
@@ -35,25 +35,26 @@ export const EDTFSingleDatePicker = ({
     handleChange(null);
   };
   return (
-    <div className="ui datepicker field">
-      <Form.Field className="ui datepicker field" required={required}>
-        <FieldLabel htmlFor={fieldPath} icon={icon} label={label} />
-        <EDTFDatePickerWrapper
-          fieldPath={fieldPath}
-          handleChange={handleChange}
-          handleClear={handleClear}
-          placeholder={placeholder}
-          dateEdtfFormat={dateEdtfFormat}
-          setDateEdtfFormat={setDateEdtfFormat}
-          dateFormat={getDateFormatStringFromEdtfFormat(dateEdtfFormat)}
-          clearButtonClassName={clearButtonClassName}
-          datePickerProps={{ selected: date, ...datePickerProps }}
-          helpText={helpText}
-          customInputProps={customInputProps}
-        />
-        <label className="helptext rel-mt-1">{helpText}</label>
-      </Form.Field>
-    </div>
+    <Form.Field className="ui datepicker field" required={required}>
+      <FieldLabel htmlFor={fieldPath} icon={icon} label={label} />
+      <EDTFDatePickerWrapper
+        fieldPath={fieldPath}
+        handleClear={handleClear}
+        placeholder={placeholder}
+        dateEdtfFormat={dateEdtfFormat}
+        setDateEdtfFormat={setDateEdtfFormat}
+        dateFormat={getDateFormatStringFromEdtfFormat(dateEdtfFormat)}
+        clearButtonClassName={clearButtonClassName}
+        datePickerProps={{
+          selected: date,
+          onChange: handleChange,
+          ...datePickerProps,
+        }}
+        helpText={helpText}
+        customInputProps={customInputProps}
+      />
+      <label className="helptext rel-mt-1">{helpText}</label>
+    </Form.Field>
   );
 };
 

--- a/oarepo_ui/theme/assets/semantic-ui/less/oarepo_ui/definitions/datepicker.less
+++ b/oarepo_ui/theme/assets/semantic-ui/less/oarepo_ui/definitions/datepicker.less
@@ -41,8 +41,14 @@ name of the component from above)
     background-color: transparent !important;
     font-size: 0.8rem;
   }
+  .field {
+    margin-bottom: 0rem !important;
+  }
   .clear-icon:hover {
     opacity: 1 !important;
+  }
+  label.helptext {
+    margin-top: 0.5rem;
   }
   label.helptext::after {
     content: "" !important;

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-ui
-version = 5.1.5
+version = 5.1.7
 description = UI module for invenio 3.5+
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
PR includes:

1. Fixed calendar positioning
2. Refactoring, so as to not render the datepicker wrapper multiple times

In this setup (not rendering multiple datepickers), I had a problem, to display the date range in to separate inputs visually, because when you are choosing daterange in one datepicker (the requirement for the calendar to not close after start date selection), the datepicker keeps start and end date as one string value in shape "date-date", and it turned out to be pretty flaky how to unpack this to separate inputs, the clearing of inputs also worked in a weird way, so I decided for selection to simply be in one input as in one of the previous iterations. I don't know if this is a deal breaker, generally I think it works quite well, and that it looks OK and reasonable. Please let me know what you think.