### PR TITLE
Stojanovic/fe 124 fix remote vocabulary select field

### DIFF
--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/RelatedSelectField/RelatedSelectField.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/RelatedSelectField/RelatedSelectField.jsx
@@ -38,6 +38,12 @@ export const RelatedSelectField = ({
   ...uiProps
 }) => {
   const { values } = useFormikContext();
+  // console.log(multiple);
+  // console.log(
+  //   deserializeValue
+  //     ? deserializeValue(getIn(values, fieldPath, multiple ? [] : {}))
+  //     : getIn(values, fieldPath, "")
+  // );
   return (
     <RelatedSelectFieldInternal
       fluid
@@ -57,21 +63,25 @@ export const RelatedSelectField = ({
       preSearchChange={preSearchChange}
       search={search}
       multiple={multiple}
-      onValueChange={({ e, data, formikProps }) => {
-        formikProps.form.setFieldValue(
-          fieldPath,
-          serializeSelectedItem ? serializeSelectedItem(data.value) : data.value
-        );
-      }}
+      // onValueChange={({ e, data, formikProps }) => {
+      //   console.log("onvaluechange");
+      //   console.log(data.value);
+      //   console.log(serializeSelectedItem(data.value));
+      //   formikProps.form.setFieldValue(
+      //     fieldPath,
+      //     serializeSelectedItem ? serializeSelectedItem(data.value) : data.value
+      //   );
+      // }}
       externalSuggestionApi={externalSuggestionApi}
       serializeExternalApiSuggestions={serializeExternalApiSuggestions}
       externalApiButtonContent={externalApiButtonContent}
       externalApiModalTitle={externalApiModalTitle}
-      value={
-        deserializeValue
-          ? deserializeValue(getIn(values, fieldPath, multiple ? [] : {}))
-          : getIn(values, fieldPath, '')
-      }
+      value={{}}
+      // value={
+      //   deserializeValue
+      //     ? deserializeValue(getIn(values, fieldPath, multiple ? [] : {}))
+      //     : getIn(values, fieldPath, "")
+      // }
       {...uiProps}
     />
   );

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/RelatedSelectField/RelatedSelectFieldInternal.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/RelatedSelectField/RelatedSelectFieldInternal.jsx
@@ -63,29 +63,6 @@ export class RelatedSelectFieldInternal extends RemoteSelectField {
     });
   };
 
-  onSelectValue = (event, { options, value }, callbackFunc) => {
-    const { multiple } = this.props;
-    console.log(multiple);
-    console.log(options);
-    console.log(value);
-    let newSelectedSuggestions = options;
-    if (multiple) {
-      newSelectedSuggestions = options.filter((item) =>
-        value.includes(item.value)
-      );
-    }
-
-    this.setState(
-      {
-        selectedSuggestions: newSelectedSuggestions,
-        searchQuery: null,
-        error: false,
-        open: !!multiple,
-      },
-      () => callbackFunc(newSelectedSuggestions)
-    );
-  };
-
   getProps = () => {
     const {
       // allow to pass a different serializer to transform data from external API in case it is needed
@@ -143,7 +120,6 @@ export class RelatedSelectFieldInternal extends RemoteSelectField {
     } = this.props;
 
     const { compProps, uiProps } = this.getProps();
-
     const searchConfig = {
       searchApi: {
         axios: {

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/RelatedSelectField/RelatedSelectFieldInternal.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/RelatedSelectField/RelatedSelectFieldInternal.jsx
@@ -10,14 +10,13 @@ import _isEmpty from "lodash/isEmpty";
 export class RelatedSelectFieldInternal extends RemoteSelectField {
   constructor(props) {
     super(props);
+    const initialSuggestions = props.initialSuggestions
+      ? props.serializeSuggestions(props.initialSuggestions)
+      : [];
     this.state = {
       ...this.state,
       isModalOpen: false,
-      suggestions: props.initialSuggestions?.length
-        ? props.initialSuggestions
-        : props.value
-        ? props.serializeSuggestions(props.value)
-        : [],
+      suggestions: initialSuggestions,
     };
     this.handleModal = this.handleModal.bind(this);
   }
@@ -62,6 +61,29 @@ export class RelatedSelectFieldInternal extends RemoteSelectField {
     this.setState({
       suggestions: [...externalApiSuggestions],
     });
+  };
+
+  onSelectValue = (event, { options, value }, callbackFunc) => {
+    const { multiple } = this.props;
+    console.log(multiple);
+    console.log(options);
+    console.log(value);
+    let newSelectedSuggestions = options;
+    if (multiple) {
+      newSelectedSuggestions = options.filter((item) =>
+        value.includes(item.value)
+      );
+    }
+
+    this.setState(
+      {
+        selectedSuggestions: newSelectedSuggestions,
+        searchQuery: null,
+        error: false,
+        open: !!multiple,
+      },
+      () => callbackFunc(newSelectedSuggestions)
+    );
   };
 
   getProps = () => {
@@ -150,7 +172,6 @@ export class RelatedSelectFieldInternal extends RemoteSelectField {
     return (
       <React.Fragment>
         <SelectField
-          {...uiProps}
           allowAdditions={this.error ? false : uiProps.allowAdditions}
           fieldPath={compProps.fieldPath}
           options={this.state.suggestions}
@@ -189,6 +210,7 @@ export class RelatedSelectFieldInternal extends RemoteSelectField {
           }}
           loading={this.isFetching}
           className="invenio-remote-select-field"
+          {...uiProps}
         />
         {externalSuggestionApi && (
           <ExternalApiModal


### PR DESCRIPTION
Refactoring of remote field. You can now select singe item. 

I've also made some checks in case we will want to replace some of the local vocabulary selectors with remotes, due to the slowness of the form (vocabularies pre fetching), and it does work OK in context of depositform. Though, having "featured" items might be more problematic, due to the fact that you dont have any suggestions when you are starting. 