### PR TITLE
wrapper cmp for displaying active filters

### DIFF
--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/search/ClearFiltersButton.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/search/ClearFiltersButton.jsx
@@ -5,7 +5,6 @@ import { i18next } from "@translations/oarepo_ui/i18next";
 import PropTypes from "prop-types";
 import { SearchConfigurationContext } from "@js/invenio_search_ui/components";
 import _uniq from "lodash/uniq";
-import { ShouldActiveFiltersRender } from "@js/oarepo_ui";
 
 // TODO: in next iteration, rethink how handling of initialFilters/ignored filters is to be handled
 // in the best way
@@ -27,23 +26,21 @@ const ClearFiltersButtonComponent = ({
     ...ignoredFilters,
   ]);
   return (
-    <ShouldActiveFiltersRender>
-      <Button
-        name="clear"
-        color="orange"
-        onClick={() =>
-          updateQueryState({
-            ...currentQueryState,
-            filters: filters.filter((f) => allFiltersToIgnore.includes(f[0])),
-          })
-        }
-        icon="delete"
-        labelPosition="left"
-        content={i18next.t("Clear all filters")}
-        type="button"
-        size="mini"
-      />
-    </ShouldActiveFiltersRender>
+    <Button
+      name="clear"
+      color="orange"
+      onClick={() =>
+        updateQueryState({
+          ...currentQueryState,
+          filters: filters.filter((f) => allFiltersToIgnore.includes(f[0])),
+        })
+      }
+      icon="delete"
+      labelPosition="left"
+      content={i18next.t("Clear all filters")}
+      type="button"
+      size="mini"
+    />
   );
 };
 

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/search/ClearFiltersButton.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/search/ClearFiltersButton.jsx
@@ -5,6 +5,7 @@ import { i18next } from "@translations/oarepo_ui/i18next";
 import PropTypes from "prop-types";
 import { SearchConfigurationContext } from "@js/invenio_search_ui/components";
 import _uniq from "lodash/uniq";
+import { ShouldActiveFiltersRender } from "@js/oarepo_ui";
 
 // TODO: in next iteration, rethink how handling of initialFilters/ignored filters is to be handled
 // in the best way
@@ -26,7 +27,7 @@ const ClearFiltersButtonComponent = ({
     ...ignoredFilters,
   ]);
   return (
-    filters.length > initialFilters?.length && (
+    <ShouldActiveFiltersRender>
       <Button
         name="clear"
         color="orange"
@@ -42,7 +43,7 @@ const ClearFiltersButtonComponent = ({
         type="button"
         size="mini"
       />
-    )
+    </ShouldActiveFiltersRender>
   );
 };
 

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/search/SearchAppLayout.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/search/SearchAppLayout.jsx
@@ -14,6 +14,7 @@ import {
 } from "@js/invenio_search_ui/components";
 import { ResultOptions } from "@js/invenio_search_ui/components/Results";
 import { ClearFiltersButton } from "./ClearFiltersButton";
+import { ShouldActiveFiltersRender } from "@js/oarepo_ui";
 
 const ResultOptionsWithState = withState(ResultOptions);
 
@@ -134,19 +135,23 @@ export const SearchAppLayout = ({ config, hasButtonSidebar }) => {
             </Grid.Column>
           )}
           {facetsAvailable && (
-            <Grid.Column floated="left" only="computer" width={11}>
-              <ActiveFilters />
-            </Grid.Column>
+            <ShouldActiveFiltersRender>
+              <Grid.Column floated="left" only="computer" width={11}>
+                <ActiveFilters />
+              </Grid.Column>
+            </ShouldActiveFiltersRender>
           )}
           <Grid.Column textAlign="right" floated="right" {...resultSortLayout}>
             <ResultOptionsWithState />
           </Grid.Column>
         </Grid.Row>
-        <Grid.Row>
-          <Grid.Column floated="left">
-            <ClearFiltersButton />
-          </Grid.Column>
-        </Grid.Row>
+        <ShouldActiveFiltersRender>
+          <Grid.Row>
+            <Grid.Column floated="left">
+              <ClearFiltersButton />
+            </Grid.Column>
+          </Grid.Row>
+        </ShouldActiveFiltersRender>
         <Grid.Row columns={columnsAmount}>
           {facetsAvailable && (
             <GridResponsiveSidebarColumn

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/search/ShouldActiveFiltersRender.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/search/ShouldActiveFiltersRender.jsx
@@ -1,0 +1,30 @@
+import React, { useContext } from "react";
+import { withState } from "react-searchkit";
+import { SearchConfigurationContext } from "@js/invenio_search_ui/components";
+import PropTypes from "prop-types";
+import { ShouldRender } from "@js/oarepo_ui";
+
+const ShouldActiveFiltersRenderComponent = ({
+  currentQueryState,
+  children,
+}) => {
+  const { filters } = currentQueryState;
+  const searchAppContext = useContext(SearchConfigurationContext);
+  const {
+    initialQueryState: { filters: initialFilters },
+  } = searchAppContext;
+  return (
+    <ShouldRender condition={filters.length > initialFilters?.length}>
+      {children}
+    </ShouldRender>
+  );
+};
+
+ShouldActiveFiltersRenderComponent.propTypes = {
+  currentQueryState: PropTypes.object.isRequired,
+  children: PropTypes.node,
+};
+
+export const ShouldActiveFiltersRender = withState(
+  ShouldActiveFiltersRenderComponent
+);

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/search/ShouldRender.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/search/ShouldRender.jsx
@@ -1,0 +1,26 @@
+import PropTypes from "prop-types";
+import { Component } from "react";
+import Overridable from "react-overridable";
+
+// For some reason, the component is not exported from React Searchkit
+
+class ShouldRenderComponent extends Component {
+  render() {
+    const { children, condition } = this.props;
+    return condition ? children : null;
+  }
+}
+
+ShouldRenderComponent.propTypes = {
+  condition: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+};
+
+ShouldRenderComponent.defaultProps = {
+  condition: true,
+};
+
+export const ShouldRender = Overridable.component(
+  "ShouldRender",
+  ShouldRenderComponent
+);

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/search/index.js
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/search/index.js
@@ -15,4 +15,6 @@ export { ResultsPerPageLabel } from "./ResultsPerPageLabel";
 export { ClearFiltersButton } from "./ClearFiltersButton";
 export { DynamicResultsListItem } from "./DynamicResultsListItem";
 export { SearchappSearchbarElement } from "./SearchappSearchbarElement";
+export { ShouldActiveFiltersRender } from "./ShouldActiveFiltersRender";
+export * from "./ShouldRender";
 export * from "./util";

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-ui
-version = 5.1.17
+version = 5.1.19
 description = UI module for invenio 3.5+
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
I find that I am often repeating same logic in terms of displaying active filters. The active filters component and clearfilters button, have mechanism to not render if certain conditions are not met, but the problem is these components are usually nested inside some grid row//column and then I get empty column or a row in the layout, which is not OK. React searchkit has a nice base for this, ShouldRender cmp, but unfortunately, that one is not exported from the library for some reason, so I pasted it into our code. I guess it could be useful in some other contexts as well in the future.