### PR TITLE
Fix BucketAggregationValues.element not being overriden

### DIFF
--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/search/constants.js
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/search/constants.js
@@ -3,6 +3,7 @@ export const overridableComponentIds = [
   "AutocompleteSearchBar.element",
   "BucketAggregation.element",
   "BucketAggregationContainer.element",
+  "BucketAggregationValues.element",
   "Count.Element",
   "Error.element",
   "Pagination.element",


### PR DESCRIPTION
Adding "BucketAggregationValues.element" to constant.js to be registered as a Overridable component