### PR TITLE
getting allowed tags and attrs from be

### DIFF
--- a/oarepo_ui/resources/components.py
+++ b/oarepo_ui/resources/components.py
@@ -275,22 +275,6 @@ class FilesComponent(UIResourceComponent):
 
 
 class AllowedHtmlTagsComponent(UIResourceComponent):
-    def calculate_valid_tags_for_editor(self, tags, attr):
-        special_attributes = {key: "|".join(value) for key, value in attr.items()}
-
-        result = []
-
-        if "*" in special_attributes:
-            result.append(f"@[{special_attributes['*']}]")
-
-        for tag in tags:
-            if tag in special_attributes:
-                result.append(f"{tag}[{special_attributes[tag]}]")
-            else:
-                result.append(tag)
-
-        return ",".join(result)
-
     def form_config(self, *, form_config, **kwargs):
         form_config["allowedHtmlTags"] = current_app.config.get(
             "ALLOWED_HTML_TAGS", ALLOWED_HTML_TAGS
@@ -298,8 +282,4 @@ class AllowedHtmlTagsComponent(UIResourceComponent):
 
         form_config["allowedHtmlAttrs"] = current_app.config.get(
             "ALLOWED_HTML_ATTRS", ALLOWED_HTML_ATTRS
-        )
-
-        form_config["validEditorTags"] = self.calculate_valid_tags_for_editor(
-            form_config["allowedHtmlTags"], form_config["allowedHtmlAttrs"]
         )

--- a/oarepo_ui/resources/components.py
+++ b/oarepo_ui/resources/components.py
@@ -5,6 +5,8 @@ from flask_principal import Identity
 from invenio_i18n.ext import current_i18n
 from invenio_records_resources.services.records.results import RecordItem
 from oarepo_runtime.datastreams.utils import get_file_service_for_record_service
+from invenio_config.default import ALLOWED_HTML_TAGS, ALLOWED_HTML_ATTRS
+
 
 from ..proxies import current_oarepo_ui
 
@@ -270,3 +272,34 @@ class FilesComponent(UIResourceComponent):
 
     def before_ui_detail(self, **kwargs):
         self.before_ui_edit(**kwargs)
+
+
+class AllowedHtmlTagsComponent(UIResourceComponent):
+    def calculate_valid_tags_for_editor(self, tags, attr):
+        special_attributes = {key: "|".join(value) for key, value in attr.items()}
+
+        result = []
+
+        if "*" in special_attributes:
+            result.append(f"@[{special_attributes['*']}]")
+
+        for tag in tags:
+            if tag in special_attributes:
+                result.append(f"{tag}[{special_attributes[tag]}]")
+            else:
+                result.append(tag)
+
+        return ",".join(result)
+
+    def form_config(self, *, form_config, **kwargs):
+        form_config["allowedHtmlTags"] = current_app.config.get(
+            "ALLOWED_HTML_TAGS", ALLOWED_HTML_TAGS
+        )
+
+        form_config["allowedHtmlAttrs"] = current_app.config.get(
+            "ALLOWED_HTML_ATTRS", ALLOWED_HTML_ATTRS
+        )
+
+        form_config["validEditorTags"] = self.calculate_valid_tags_for_editor(
+            form_config["allowedHtmlTags"], form_config["allowedHtmlAttrs"]
+        )

--- a/oarepo_ui/resources/resource.py
+++ b/oarepo_ui/resources/resource.py
@@ -48,23 +48,6 @@ from .config import (
 )
 
 
-def calculate_valid_tags_for_editor(tags=None, attr=None):
-    special_attributes = {key: "|".join(value) for key, value in attr.items()}
-
-    result = []
-
-    if "*" in special_attributes:
-        result.append(f"@[{special_attributes['*']}]")
-
-    for tag in tags:
-        if tag in special_attributes:
-            result.append(f"{tag}[{special_attributes[tag]}]")
-        else:
-            result.append(tag)
-
-    return ",".join(result)
-
-
 request_export_args = request_parser(
     from_conf("request_export_args"), location="view_args"
 )

--- a/oarepo_ui/resources/resource.py
+++ b/oarepo_ui/resources/resource.py
@@ -4,7 +4,7 @@ from os.path import splitext
 from typing import TYPE_CHECKING, Iterator
 
 import deepmerge
-from flask import abort, g, redirect, request, current_app
+from flask import abort, g, redirect, request
 from flask_principal import PermissionDenied
 from flask_resources import (
     Resource,
@@ -32,7 +32,6 @@ from oarepo_runtime.datastreams.utils import get_file_service_for_record_class
 
 from .templating.data import FieldData
 from invenio_previewer.extensions import default as default_previewer
-from invenio_config.default import ALLOWED_HTML_TAGS, ALLOWED_HTML_ATTRS
 
 
 if TYPE_CHECKING:
@@ -449,22 +448,6 @@ class RecordsUIResource(UIResource):
         form_config["custom_fields"] = self._get_custom_fields(
             api_record=api_record, resource_requestctx=resource_requestctx
         )
-        # TODO: it is getting a bit crowded in the resource, the issue is that we dont't really use any components
-        # in the config on the level of oarepo ui, i.e. they are only used in the config of specific resources inside apps
-        # so if we wish to start having some basic components array in config in oarepo ui, it would require refactor
-        # in all apps (to use also components on the upstream oarepo ui config and then any new ones on the level of the app)
-
-        form_config["allowedHtmlTags"] = current_app.config.get(
-            "ALLOWED_HTML_TAGS", ALLOWED_HTML_TAGS
-        )
-
-        form_config["allowedHtmlAttrs"] = current_app.config.get(
-            "ALLOWED_HTML_ATTRS", ALLOWED_HTML_ATTRS
-        )
-
-        form_config["validEditorTags"] = calculate_valid_tags_for_editor(
-            form_config["allowedHtmlTags"], form_config["allowedHtmlAttrs"]
-        )
 
         ui_links = self.expand_detail_links(identity=g.identity, record=api_record)
 
@@ -540,18 +523,6 @@ class RecordsUIResource(UIResource):
         )
         form_config["custom_fields"] = self._get_custom_fields(
             resource_requestctx=resource_requestctx
-        )
-
-        form_config["allowedHtmlTags"] = current_app.config.get(
-            "ALLOWED_HTML_TAGS", ALLOWED_HTML_TAGS
-        )
-
-        form_config["allowedHtmlAttrs"] = current_app.config.get(
-            "ALLOWED_HTML_ATTRS", ALLOWED_HTML_ATTRS
-        )
-
-        form_config["validEditorTags"] = calculate_valid_tags_for_editor(
-            form_config["allowedHtmlTags"], form_config["allowedHtmlAttrs"]
         )
 
         extra_context = dict()

--- a/oarepo_ui/resources/resource.py
+++ b/oarepo_ui/resources/resource.py
@@ -49,10 +49,14 @@ from .config import (
 )
 
 
-def valid_tags(tags=None, attr=None):
+def calculate_valid_tags_for_editor(tags=None, attr=None):
     special_attributes = {key: "|".join(value) for key, value in attr.items()}
 
     result = []
+
+    if "*" in special_attributes:
+        result.append(f"@[{special_attributes['*']}]")
+
     for tag in tags:
         if tag in special_attributes:
             result.append(f"{tag}[{special_attributes[tag]}]")
@@ -458,7 +462,7 @@ class RecordsUIResource(UIResource):
             "ALLOWED_HTML_ATTRS", ALLOWED_HTML_ATTRS
         )
 
-        form_config["validEditorTags"] = valid_tags(
+        form_config["validEditorTags"] = calculate_valid_tags_for_editor(
             form_config["allowedHtmlTags"], form_config["allowedHtmlAttrs"]
         )
 
@@ -546,7 +550,7 @@ class RecordsUIResource(UIResource):
             "ALLOWED_HTML_ATTRS", ALLOWED_HTML_ATTRS
         )
 
-        form_config["validEditorTags"] = valid_tags(
+        form_config["validEditorTags"] = calculate_valid_tags_for_editor(
             form_config["allowedHtmlTags"], form_config["allowedHtmlAttrs"]
         )
 

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/I18nRichInputField/I18nRichInputField.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/I18nRichInputField/I18nRichInputField.jsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { LanguageSelectField } from "@js/oarepo_ui";
+import { LanguageSelectField, useSanitizeInput } from "@js/oarepo_ui";
 import {
   RichInputField,
   GroupField,
@@ -9,7 +9,6 @@ import {
 import PropTypes from "prop-types";
 import { Form } from "semantic-ui-react";
 import { useFormikContext, getIn } from "formik";
-import { sanitizeInput } from "../../util";
 
 export const I18nRichInputField = ({
   fieldPath,
@@ -25,9 +24,8 @@ export const I18nRichInputField = ({
   ...uiProps
 }) => {
   const { values, setFieldValue, setFieldTouched } = useFormikContext();
-
+  const { sanitizeInput } = useSanitizeInput();
   const fieldValue = getIn(values, `${fieldPath}.value`);
-
   return (
     <GroupField fieldPath={fieldPath} optimized>
       <LanguageSelectField
@@ -39,7 +37,6 @@ export const I18nRichInputField = ({
 
       <Form.Field width={13}>
         <RichInputField
-          className={`${!label ? "mt-25" : ""}`}
           fieldPath={`${fieldPath}.value`}
           label={
             <FieldLabel
@@ -57,10 +54,7 @@ export const I18nRichInputField = ({
               optimized
               editorConfig={editorConfig}
               onBlur={(event, editor) => {
-                const cleanedContent = sanitizeInput(
-                  editor.getContent(),
-                  validTags
-                );
+                const cleanedContent = sanitizeInput(editor.getContent());
                 setFieldValue(`${fieldPath}.value`, cleanedContent);
                 setFieldTouched(`${fieldPath}.value`, true);
               }}

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/I18nTextInputField/I18nTextInputField.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/I18nTextInputField/I18nTextInputField.jsx
@@ -1,9 +1,8 @@
 import * as React from "react";
-import { LanguageSelectField } from "@js/oarepo_ui";
+import { LanguageSelectField, useSanitizeInput } from "@js/oarepo_ui";
 import { TextField, GroupField, FieldLabel } from "react-invenio-forms";
 import PropTypes from "prop-types";
 import { useFormikContext, getIn } from "formik";
-import { sanitizeInput } from "../../util";
 
 export const I18nTextInputField = ({
   fieldPath,
@@ -18,6 +17,7 @@ export const I18nTextInputField = ({
   ...uiProps
 }) => {
   const { values, setFieldValue, setFieldTouched } = useFormikContext();
+  const { sanitizeInput } = useSanitizeInput();
 
   return (
     <GroupField fieldPath={fieldPath} optimized>
@@ -29,9 +29,6 @@ export const I18nTextInputField = ({
         usedLanguages={usedLanguages}
       />
       <TextField
-        // TODO: hacky fix for SUI alignment bug for case with
-        // field groups with empty field label on one of inputs
-        className={`${!label ? "mt-20" : ""}`}
         fieldPath={`${fieldPath}.value`}
         label={
           <FieldLabel
@@ -46,8 +43,7 @@ export const I18nTextInputField = ({
         width={13}
         onBlur={() => {
           const cleanedContent = sanitizeInput(
-            getIn(values, `${fieldPath}.value`),
-            validTags
+            getIn(values, `${fieldPath}.value`)
           );
           setFieldValue(`${fieldPath}.value`, cleanedContent);
           setFieldTouched(`${fieldPath}.value`, true);

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/hooks.js
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/hooks.js
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useState, useContext } from "react";
+import { useEffect, useCallback, useState, useContext, useMemo } from "react";
 import { FormConfigContext } from "./contexts";
 import {
   OARepoDepositApiClient,
@@ -16,6 +16,7 @@ import { i18next } from "@translations/oarepo_ui/i18next";
 import { relativeUrl } from "../util";
 import { decode } from "html-entities";
 import sanitizeHtml from "sanitize-html";
+import { getValidTagsForEditor } from "@js/oarepo_ui";
 
 export const extractFEErrorMessages = (obj) => {
   const errorMessages = [];
@@ -467,11 +468,15 @@ export const useSanitizeInput = () => {
     },
     [allowedHtmlTags, allowedHtmlAttrs]
   );
-
+  const vailidEditorTags = useMemo(
+    () => getValidTagsForEditor(allowedHtmlTags, allowedHtmlAttrs),
+    [allowedHtmlTags, allowedHtmlAttrs]
+  );
   return {
     sanitizeInput,
     allowedHtmlAttrs,
     allowedHtmlTags,
+    vailidEditorTags,
   };
 };
 

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/hooks.js
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/hooks.js
@@ -14,6 +14,8 @@ import _isEmpty from "lodash/isEmpty";
 import _isObject from "lodash/isObject";
 import { i18next } from "@translations/oarepo_ui/i18next";
 import { relativeUrl } from "../util";
+import { decode } from "html-entities";
+import sanitizeHtml from "sanitize-html";
 
 export const extractFEErrorMessages = (obj) => {
   const errorMessages = [];
@@ -447,4 +449,25 @@ export const useValidateOnBlur = () => {
   const { validateField, setFieldTouched } = useFormikContext();
 
   return handleValidateAndBlur(validateField, setFieldTouched);
+};
+
+const sanitizeInput = (allowedHtmlTags, allowedHtmlAttrs) => (htmlString) => {
+  const decodedString = decode(htmlString);
+  const cleanInput = sanitizeHtml(decodedString, {
+    allowedTags: allowedHtmlTags,
+    allowedAttributes: allowedHtmlAttrs,
+  });
+  return cleanInput;
+};
+
+export const useSanitizeInput = () => {
+  const {
+    formConfig: { allowedHtmlAttrs, allowedHtmlTags, validEditorTags },
+  } = useFormConfig();
+  return {
+    sanitizeInput: sanitizeInput(allowedHtmlTags, allowedHtmlAttrs),
+    allowedHtmlAttrs,
+    allowedHtmlTags,
+    validEditorTags,
+  };
 };

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/hooks.js
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/hooks.js
@@ -451,23 +451,28 @@ export const useValidateOnBlur = () => {
   return handleValidateAndBlur(validateField, setFieldTouched);
 };
 
-const sanitizeInput = (allowedHtmlTags, allowedHtmlAttrs) => (htmlString) => {
-  const decodedString = decode(htmlString);
-  const cleanInput = sanitizeHtml(decodedString, {
-    allowedTags: allowedHtmlTags,
-    allowedAttributes: allowedHtmlAttrs,
-  });
-  return cleanInput;
-};
-
 export const useSanitizeInput = () => {
   const {
-    formConfig: { allowedHtmlAttrs, allowedHtmlTags, validEditorTags },
+    formConfig: { allowedHtmlAttrs, allowedHtmlTags },
   } = useFormConfig();
+
+  const sanitizeInput = useCallback(
+    (htmlString) => {
+      const decodedString = decode(htmlString);
+      const cleanInput = sanitizeHtml(decodedString, {
+        allowedTags: allowedHtmlTags,
+        allowedAttributes: allowedHtmlAttrs,
+      });
+      return cleanInput;
+    },
+    [allowedHtmlTags, allowedHtmlAttrs]
+  );
+
   return {
-    sanitizeInput: sanitizeInput(allowedHtmlTags, allowedHtmlAttrs),
+    sanitizeInput,
     allowedHtmlAttrs,
     allowedHtmlTags,
-    validEditorTags,
   };
 };
+
+export default useSanitizeInput;

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/hooks.js
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/hooks.js
@@ -468,7 +468,7 @@ export const useSanitizeInput = () => {
     },
     [allowedHtmlTags, allowedHtmlAttrs]
   );
-  const vailidEditorTags = useMemo(
+  const validEditorTags = useMemo(
     () => getValidTagsForEditor(allowedHtmlTags, allowedHtmlAttrs),
     [allowedHtmlTags, allowedHtmlAttrs]
   );
@@ -476,7 +476,7 @@ export const useSanitizeInput = () => {
     sanitizeInput,
     allowedHtmlAttrs,
     allowedHtmlTags,
-    vailidEditorTags,
+    validEditorTags,
   };
 };
 

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/util.js
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/util.js
@@ -13,8 +13,6 @@ import Overridable, {
   overrideStore,
 } from "react-overridable";
 import { BaseFormLayout } from "./components/BaseFormLayout";
-import { decode } from "html-entities";
-import sanitizeHtml from "sanitize-html";
 
 export function parseFormAppConfig(rootElementId = "form-app") {
   const rootEl = document.getElementById(rootElementId);
@@ -26,67 +24,6 @@ export function parseFormAppConfig(rootElementId = "form-app") {
 
   return { rootEl, record, formConfig, recordPermissions, files, links };
 }
-
-const allowed_tags = [
-  "a",
-  "abbr",
-  "acronym",
-  "b",
-  "blockquote",
-  "br",
-  "code",
-  "div",
-  "table",
-  "tbody",
-  "td",
-  "th",
-  "tr",
-  "em",
-  "h1",
-  "h2",
-  "h3",
-  "h4",
-  "h5",
-  "i",
-  "li",
-  "ol",
-  "p",
-  "pre",
-  "span",
-  "strike",
-  "strong",
-  "sub",
-  "sup",
-  "u",
-  "ul",
-];
-
-const allowed_attr = {
-  a: ["href", "title", "name", "target", "rel"],
-  abbr: ["title"],
-  acronym: ["title"],
-};
-
-export const validTags = (tags = allowed_tags, attr = allowed_attr) => {
-  const specialAttributes = Object.fromEntries(
-    Object.entries(attr).map(([key, value]) => [key, value.join("|")])
-  );
-
-  return tags
-    .map((tag) => {
-      return specialAttributes[tag] ? `${tag}[${specialAttributes[tag]}]` : tag;
-    })
-    .join(",");
-};
-
-export const sanitizeInput = (htmlString, validTags) => {
-  const decodedString = decode(htmlString);
-  const cleanInput = sanitizeHtml(decodedString, {
-    allowedTags: validTags || allowed_tags,
-    allowedAttributes: allowed_attr,
-  });
-  return cleanInput;
-};
 
 /**
  * Initialize Formik form application.

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/util.js
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/util.js
@@ -80,3 +80,22 @@ export function createFormAppInit({
     return initFormApp;
   }
 }
+
+export const getValidTagsForEditor = (tags, attr) => {
+  const specialAttributes = Object.fromEntries(
+    Object.entries(attr).map(([key, value]) => [key, value.join("|")])
+  );
+  let result = [];
+
+  if (specialAttributes["*"]) {
+    result.push(`@[${specialAttributes["*"]}]`);
+  }
+
+  result = result.concat(
+    tags.map((tag) => {
+      return specialAttributes[tag] ? `${tag}[${specialAttributes[tag]}]` : tag;
+    })
+  );
+
+  return result.join(",");
+};

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-ui
-version = 5.1.37
+version = 5.1.38
 description = UI module for invenio 3.5+
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/model.py
+++ b/tests/model.py
@@ -24,7 +24,10 @@ from oarepo_ui.resources import (
     RecordsUIResource,
     RecordsUIResourceConfig,
 )
-from oarepo_ui.resources.components import PermissionsComponent
+from oarepo_ui.resources.components import (
+    PermissionsComponent,
+    AllowedHtmlTagsComponent,
+)
 from oarepo_ui.resources.config import TemplatePageUIResourceConfig
 from oarepo_ui.resources.resource import TemplatePageUIResource
 
@@ -106,7 +109,7 @@ class ModelUIResourceConfig(RecordsUIResourceConfig):
         "edit": "TestEdit",
     }
 
-    components = [BabelComponent, PermissionsComponent]
+    components = [BabelComponent, PermissionsComponent, AllowedHtmlTagsComponent]
 
 
 class ModelUIResource(RecordsUIResource):

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1,4 +1,5 @@
 import json
+from invenio_config.default import ALLOWED_HTML_TAGS, ALLOWED_HTML_ATTRS
 
 
 def test_create(
@@ -29,6 +30,9 @@ def test_create(
                 }
             },
             "form_config": {
+                "allowedHtmlTags": ALLOWED_HTML_TAGS,
+                "allowedHtmlAttrs": ALLOWED_HTML_ATTRS,
+                "validEditorTags": "@[class],a[href|title|name|class|rel],abbr[title],acronym[title],b,blockquote,br,code,div,table,tbody,td,th,tr,em,h1,h2,h3,h4,h5,i,li,ol,p,pre,span,strike,strong,sub,sup,u,ul",
                 "createUrl": "/api/simple-model",
                 "current_locale": "en",
                 "custom_fields": {

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -32,7 +32,6 @@ def test_create(
             "form_config": {
                 "allowedHtmlTags": ALLOWED_HTML_TAGS,
                 "allowedHtmlAttrs": ALLOWED_HTML_ATTRS,
-                "validEditorTags": "@[class],a[href|title|name|class|rel],abbr[title],acronym[title],b,blockquote,br,code,div,table,tbody,td,th,tr,em,h1,h2,h3,h4,h5,i,li,ol,p,pre,span,strike,strong,sub,sup,u,ul",
                 "createUrl": "/api/simple-model",
                 "current_locale": "en",
                 "custom_fields": {

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -1,4 +1,5 @@
 import json
+from invenio_config.default import ALLOWED_HTML_TAGS, ALLOWED_HTML_ATTRS
 
 
 def test_edit(
@@ -35,6 +36,9 @@ def test_edit(
                 }
             },
             "form_config": {
+                "allowedHtmlTags": ALLOWED_HTML_TAGS,
+                "allowedHtmlAttrs": ALLOWED_HTML_ATTRS,
+                "validEditorTags": "@[class],a[href|title|name|class|rel],abbr[title],acronym[title],b,blockquote,br,code,div,table,tbody,td,th,tr,em,h1,h2,h3,h4,h5,i,li,ol,p,pre,span,strike,strong,sub,sup,u,ul",
                 "current_locale": "en",
                 "custom_fields": {
                     "ui": [

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -38,7 +38,6 @@ def test_edit(
             "form_config": {
                 "allowedHtmlTags": ALLOWED_HTML_TAGS,
                 "allowedHtmlAttrs": ALLOWED_HTML_ATTRS,
-                "validEditorTags": "@[class],a[href|title|name|class|rel],abbr[title],acronym[title],b,blockquote,br,code,div,table,tbody,td,th,tr,em,h1,h2,h3,h4,h5,i,li,ol,p,pre,span,strike,strong,sub,sup,u,ul",
                 "current_locale": "en",
                 "custom_fields": {
                     "ui": [

--- a/tests/test_ui_resource_config.py
+++ b/tests/test_ui_resource_config.py
@@ -1,4 +1,5 @@
 from invenio_access.permissions import system_identity
+from invenio_config.default import ALLOWED_HTML_TAGS, ALLOWED_HTML_ATTRS
 
 
 def test_ui_resource_form_config(app, test_record_ui_resource):
@@ -28,6 +29,9 @@ def test_ui_resource_form_config(app, test_record_ui_resource):
             {"value": "en", "text": "English"},
             {"value": "cs", "text": "čeština"},
         ],
+        allowedHtmlTags=ALLOWED_HTML_TAGS,
+        allowedHtmlAttrs=ALLOWED_HTML_ATTRS,
+        validEditorTags="@[class],a[href|title|name|class|rel],abbr[title],acronym[title],b,blockquote,br,code,div,table,tbody,td,th,tr,em,h1,h2,h3,h4,h5,i,li,ol,p,pre,span,strike,strong,sub,sup,u,ul",
         default_locale="en",
         overridableIdPrefix="Test.Form",
         permissions={

--- a/tests/test_ui_resource_config.py
+++ b/tests/test_ui_resource_config.py
@@ -31,7 +31,6 @@ def test_ui_resource_form_config(app, test_record_ui_resource):
         ],
         allowedHtmlTags=ALLOWED_HTML_TAGS,
         allowedHtmlAttrs=ALLOWED_HTML_ATTRS,
-        validEditorTags="@[class],a[href|title|name|class|rel],abbr[title],acronym[title],b,blockquote,br,code,div,table,tbody,td,th,tr,em,h1,h2,h3,h4,h5,i,li,ol,p,pre,span,strike,strong,sub,sup,u,ul",
         default_locale="en",
         overridableIdPrefix="Test.Form",
         permissions={


### PR DESCRIPTION
Proposal how to propagate html tags/attrs to front end. It required also changing the function in js, because you cannot take from context inside of a javascript function. 

I also moved "calculation" of tags for the editor to the BE, because I thought it made sense for it to be calculated only one time during lifecycle of the form and all the data are already available there.

@AlbinaMakisheva Please take a look and tell me if you think this is OK

@mirekys I am not sure about crowding the resource in this way. It would be cleaner to do this via a component, but the issue is, we don't have any components used in the config on the level of oarepo ui, so if I would add a component for adding this to form config and used it in config in oarepo ui, then I would need to modify in all apps, that components first call any potential components from the parent config, before applying the app specific components to config i.e. something like this in nr-docs

class DocumentsResourceConfig(RecordsUIResourceConfig):
    template_folder = "templates"
    url_prefix = "/docs/"
    blueprint_name = "documents"
    ui_serializer_class = "documents.resources.records.ui.DocumentsUIJSONSerializer"
    api_service = "documents"

    components = [
        *RecordsUIResourceConfig.components, (use upstream cmps first)
        BabelComponent,
        DepositVocabularyOptionsComponent,
        PermissionsComponent,
        FilesComponent,
    ]