### PR TITLE
fix(vocabularies): pass searchQueryParamName as a property

### DIFF
--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/RelatedSelectField/RelatedSelectFieldInternal.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/RelatedSelectField/RelatedSelectFieldInternal.jsx
@@ -241,6 +241,7 @@ RelatedSelectFieldInternal.propTypes = {
   serializeExternalApiSuggestions: PropTypes.func,
   externalApiButtonContent: PropTypes.string,
   externalApiModalTitle: PropTypes.string,
+  searchQueryParamName: PropTypes.string,
 };
 
 RelatedSelectFieldInternal.defaultProps = {
@@ -261,4 +262,5 @@ RelatedSelectFieldInternal.defaultProps = {
   externalApiButtonContent: i18next.t("Search External Database"),
   externalApiModalTitle: i18next.t("Search results from external API"),
   serializeExternalApiSuggestions: undefined,
+  searchQueryParamName: "suggest",
 };

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-ui
-version = 5.1.35
+version = 5.1.36
 description = UI module for invenio 3.5+
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Fixes RemoteSelect search by setting default searchQueryParamName prop according to:  https://github.com/inveniosoftware/react-invenio-forms/commit/8afbdccc6b70eedd96dc5c58d0dfb51f49000cba