### PR TITLE
modified identifierbadge

### DIFF
--- a/oarepo_ui/templates/components/IdentifierBadge.jinja
+++ b/oarepo_ui/templates/components/IdentifierBadge.jinja
@@ -32,7 +32,7 @@
     {% elif lowercaseScheme == "doi" %}
       {% set link = "https://doi.org/" + value %}
       {% set badgeTitle = creatibutorName + ": " + _('DOI profile') %}
-      {% set icon = "/static/images/identifiers/id.png" %}
+      {% set icon = "/static/images/identifiers/DOI_logo.svg" %}
       {% set alt = "DOI logo" %}
     {% elif lowercaseScheme == "gnd" %}
       {% set link = "https://d-nb.info/gnd/" + value %}

--- a/oarepo_ui/templates/components/IdentifierBadge.jinja
+++ b/oarepo_ui/templates/components/IdentifierBadge.jinja
@@ -1,54 +1,84 @@
-{#def identifier, creatibutorName, ui=None #}
-{% set scheme = identifier.scheme.lower() %}
-{% set value = identifier.identifier %}
+{#def identifier=None, creatibutorName=None #}
+{%if identifier %}
+    {% set scheme = identifier.scheme %}
+    {% set value = identifier.identifier %}
+    {% set lowercaseScheme = identifier.scheme.lower() %}
 
-{% if scheme == "orcid" %}
-  {% set link = "https://orcid.org/" + value %}
-  {% set linkTitle = creatibutorName + ": " + _('ORCID profile') %}
-  {% set icon = "/static/images/identifiers/orcid-og-image.png" %}
-  {% set alt = "ORCID logo" %}
-{% elif scheme == "scopusid" %}
-  {% set link = "https://www.scopus.com/authid/detail.uri?authorId=" + value %}
-  {% set linkTitle = creatibutorName + ": " + _('Scopus ID profile') %}
-  {% set icon = "/static/images/scopus.svg" %}
-  {% set alt = "ScopusID logo" %}
-{% elif scheme == "ror" %}
-  {% set link = "https://ror.org/" + value %}
-  {% set linkTitle = creatibutorName + ": " + _('ROR profile') %}
-  {% set icon = "/static/images/orcid.png" %}
-  {% set alt = "ROR logo" %}
-{% elif scheme == "researcherid" %}
-  {% set link = "https://www.webofscience.com/wos/author/record/" + value %}
-  {% set linkTitle = creatibutorName + ": " + _('WOS Researcher ID') %}
-  {% set icon = "/static/images/orcid.png" %}
-  {% set alt = "WOS Researcher ID logo" %}
-{% elif scheme == "doi" %}
-  {% set link = "https://doi.org/" + value %}
-  {% set linkTitle = creatibutorName + ": " + _('DOI profile') %}
-  {% set icon = "/static/images/orcid.png" %}
-  {% set alt = "DOI logo" %}
-{% elif scheme == "gnd" %}
-  {% set link = "https://d-nb.info/gnd/" + value %}
-  {% set linkTitle = creatibutorName + ": " + _('GND profile') %}
-  {% set icon = "/static/images/orcid.png" %}
-  {% set alt = "GND logo" %}
-{% else %}
-  {% set link = None %}
-  {% set linkTitle = None %}
-  {% set icon = None %}
-  {% set alt = "" %}
-{% endif %}
+    {% if lowercaseScheme == "orcid" %}
+      {% set link = "https://orcid.org/" + value %}
+      {% set badgeTitle = creatibutorName + ": " + _('ORCID profile') %}
+      {% set icon = "/static/images/identifiers/ORCID-iD_icon-vector.svg" %}
+      {% set alt = "ORCID logo" %}
+    {% elif lowercaseScheme == "scopusid" %}
+      {% set link = "https://www.scopus.com/authid/detail.uri?authorId=" + value %}
+      {% set badgeTitle = creatibutorName + ": " + _('Scopus ID profile') %}
+      {% set icon = "/static/images/identifiers/id.png" %}
+      {% set alt = "ScopusID logo" %}
+    {% elif lowercaseScheme == "ror" %}
+      {% set link = "https://ror.org/" + value %}
+      {% set badgeTitle = creatibutorName + ": " + _('ROR profile') %}
+      {% set icon = "/static/images/identifiers/ror-icon-rgb.svg" %}
+      {% set alt = "ROR logo" %}
+    {% elif lowercaseScheme == "researcherid" %}
+      {% set link = "https://www.webofscience.com/wos/author/record/" + value %}
+      {% set badgeTitle = creatibutorName + ": " + _('WOS Researcher ID') %}
+      {% set icon = "/static/images/identifiers/id.png" %}
+      {% set alt = "WOS Researcher ID logo" %}
+    {% elif lowercaseScheme == "isni" %}
+      {% set link = "https://isni.org/isni/" + value %}
+      {% set badgeTitle = creatibutorName + ": " + _('ISNI profile') %}
+      {% set icon = "/static/images/identifiers/id.png" %}
+      {% set alt = "ISNI logo" %}
+    {% elif lowercaseScheme == "doi" %}
+      {% set link = "https://doi.org/" + value %}
+      {% set badgeTitle = creatibutorName + ": " + _('DOI profile') %}
+      {% set icon = "/static/images/identifiers/id.png" %}
+      {% set alt = "DOI logo" %}
+    {% elif lowercaseScheme == "gnd" %}
+      {% set link = "https://d-nb.info/gnd/" + value %}
+      {% set badgeTitle = creatibutorName + ": " + _('GND profile') %}
+      {% set icon = "/static/images/identifiers/id.png" %}
+      {% set alt = "GND logo" %}
+    {% elif lowercaseScheme == "czenasautid" %}
+      {% set link = None %}
+      {% set badgeTitle = scheme + " " + value %}
+      {% set icon = "/static/images/identifiers/id.png" %}
+      {% set alt = "CZENAS logo" %}
+    {% elif lowercaseScheme == "vedidk" %}
+      {% set link = None %}
+      {% set badgeTitle = scheme + " " + value %}
+      {% set icon = "/static/images/identifiers/id.png" %}
+      {% set alt = "VEDIDK logo" %}
+    {% elif lowercaseScheme == "institutionalid" %}
+      {% set link = None %}
+      {% set badgeTitle = scheme + " " + value %}
+      {% set icon = "/static/images/identifiers/id.png" %}
+      {% set alt = "Institutional ID logo" %}
+    {% elif lowercaseScheme == "ico" %}
+      {% set link = None %}
+      {% set badgeTitle = scheme + " " + value %}
+      {% set icon = "/static/images/identifiers/id.png" %}
+      {% set alt = "ICO logo" %}
+    {% else %}
+      {% set link = None %}
+      {% set badgeTitle = None %}
+      {% set icon = None %}
+      {% set alt = "" %}
+    {% endif %}
+  {% endif %}
 
-{% if link %}
-  <a
-    class="no-text-decoration mr-0"
-    href="{{ link }}"
-    aria-label="{{ linkTitle }}"
-    title="{{ linkTitle }}"
-    key="{{ link }}"
-    rel="noopener noreferrer"
-    target="_blank"
-  >
-    <img class="inline-id-icon ml-5  identifier-badge" src="{{ icon }}" alt="{{ alt }}" />
-  </a>
-{% endif %}
+  {% if link %}
+    <a
+      class="no-text-decoration mr-0"
+      href="{{ link }}"
+      aria-label="{{ badgeTitle }}"
+      title="{{ badgeTitle }}"
+      key="{{ link }}"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <img class="inline-id-icon identifier-badge" src="{{ icon }}" alt="{{ alt }}" />
+    </a>
+  {% else %}
+      <img title="{{ badgeTitle }}" class="inline-id-icon identifier-badge" src="{{ icon }}" alt="{{ alt }}" />
+  {% endif %}


### PR DESCRIPTION
Fixed the creatibutors identifiers to display only one identifier, giving privilege to orcid/ror. 
For some types of identifiers (ICO, institutionalid, vedidk and czenasautid), I was unable to find the way to construct meaningful URLs that would actually take the user somewhere where they can see details of that ID, so they are just images. It is possible they exist, but that I was just not able to find them. If they do, and you know them, please provide them to me and I will correct the code. 

Related PRs:

https://github.com/Narodni-repozitar/nr-model/pull/61

https://github.com/Narodni-repozitar/nr-docs/pull/160