### PR TITLE
fixed issue with rich editor

### DIFF
--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/I18nRichInputField/I18nRichInputField.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/I18nRichInputField/I18nRichInputField.jsx
@@ -3,8 +3,9 @@ import {
   LanguageSelectField,
   useSanitizeInput,
   useFieldData,
+  OarepoRichEditor,
 } from "@js/oarepo_ui";
-import { RichInputField, GroupField, RichEditor } from "react-invenio-forms";
+import { RichInputField, GroupField } from "react-invenio-forms";
 import PropTypes from "prop-types";
 import { Form } from "semantic-ui-react";
 import { useFormikContext, getIn } from "formik";
@@ -41,18 +42,8 @@ export const I18nRichInputField = ({
         <RichInputField
           fieldPath={textFieldPath}
           optimized={optimized}
-          editor={
-            <RichEditor
-              value={fieldValue}
-              optimized
-              editorConfig={editorConfig}
-              onBlur={(event, editor) => {
-                const cleanedContent = sanitizeInput(editor.getContent());
-                setFieldValue(textFieldPath, cleanedContent);
-                setFieldTouched(textFieldPath, true);
-              }}
-            />
-          }
+          editorConfig={editorConfig}
+          editor={<OarepoRichEditor fieldPath={textFieldPath} />}
           {...uiProps}
           {...getFieldData({
             fieldPath: textFieldPath,
@@ -74,19 +65,5 @@ I18nRichInputField.propTypes = {
 
 I18nRichInputField.defaultProps = {
   optimized: true,
-  editorConfig: {
-    removePlugins: [
-      "Image",
-      "ImageCaption",
-      "ImageStyle",
-      "ImageToolbar",
-      "ImageUpload",
-      "MediaEmbed",
-      "Table",
-      "TableToolbar",
-      "TableProperties",
-      "TableCellProperties",
-    ],
-  },
   lngFieldWidth: 3,
 };

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/I18nRichInputField/I18nRichInputField.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/I18nRichInputField/I18nRichInputField.jsx
@@ -1,14 +1,12 @@
 import * as React from "react";
 import {
   LanguageSelectField,
-  useSanitizeInput,
   useFieldData,
   OarepoRichEditor,
 } from "@js/oarepo_ui";
 import { RichInputField, GroupField } from "react-invenio-forms";
 import PropTypes from "prop-types";
 import { Form } from "semantic-ui-react";
-import { useFormikContext, getIn } from "formik";
 
 export const I18nRichInputField = ({
   fieldPath,
@@ -18,11 +16,8 @@ export const I18nRichInputField = ({
   usedLanguages,
   ...uiProps
 }) => {
-  const { values, setFieldValue, setFieldTouched } = useFormikContext();
-  const { sanitizeInput } = useSanitizeInput();
   const lngFieldPath = `${fieldPath}.lang`;
   const textFieldPath = `${fieldPath}.value`;
-  const fieldValue = getIn(values, textFieldPath);
   const { getFieldData } = useFieldData();
 
   return (
@@ -42,7 +37,6 @@ export const I18nRichInputField = ({
         <RichInputField
           fieldPath={textFieldPath}
           optimized={optimized}
-          editorConfig={editorConfig}
           editor={<OarepoRichEditor fieldPath={textFieldPath} />}
           {...uiProps}
           {...getFieldData({

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/I18nRichInputField/OarepoRichEditor.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/I18nRichInputField/OarepoRichEditor.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { RichEditor } from "react-invenio-forms";
+import { useFormikContext, getIn } from "formik";
+import { useSanitizeInput } from "@js/oarepo_ui";
+import PropTypes from "prop-types";
+
+export const OarepoRichEditor = ({ fieldPath, editorConfig }) => {
+  const { sanitizeInput, validEditorTags } = useSanitizeInput();
+
+  const { values, setFieldValue, setFieldTouched } = useFormikContext();
+  const fieldValue = getIn(values, fieldPath, "");
+  return (
+    <RichEditor
+      initialValue={fieldValue}
+      inputValue={() => fieldValue}
+      optimized
+      onBlur={(event, editor) => {
+        const cleanedContent = sanitizeInput(editor.getContent());
+        setFieldValue(fieldPath, cleanedContent);
+        setFieldTouched(fieldPath, true);
+      }}
+      editorConfig={{
+        valid_elements: validEditorTags,
+        toolbar: "bold italic | bullist numlist | outdent indent | undo redo",
+        ...editorConfig,
+      }}
+    />
+  );
+};
+
+OarepoRichEditor.propTypes = {
+  fieldPath: PropTypes.string.isRequired,
+  editorConfig: PropTypes.object,
+};

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/I18nRichInputField/OarepoRichEditor.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/I18nRichInputField/OarepoRichEditor.jsx
@@ -21,7 +21,9 @@ export const OarepoRichEditor = ({ fieldPath, editorConfig }) => {
       }}
       editorConfig={{
         valid_elements: validEditorTags,
-        toolbar: "bold italic | bullist numlist | outdent indent | undo redo",
+        toolbar:
+          "blocks | bold italic | bullist numlist | outdent indent | undo redo",
+        block_formats: "Paragraph=p; Header 1=h1; Header 2=h2; Header 3=h3",
         ...editorConfig,
       }}
     />

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/I18nRichInputField/OarepoRichEditor.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/I18nRichInputField/OarepoRichEditor.jsx
@@ -4,6 +4,9 @@ import { useFormikContext, getIn } from "formik";
 import { useSanitizeInput } from "@js/oarepo_ui";
 import PropTypes from "prop-types";
 
+export const toolBar =
+  "blocks | bold italic | bullist numlist | outdent indent | undo redo";
+
 export const OarepoRichEditor = ({ fieldPath, editorConfig }) => {
   const { sanitizeInput, validEditorTags } = useSanitizeInput();
 
@@ -21,9 +24,7 @@ export const OarepoRichEditor = ({ fieldPath, editorConfig }) => {
       }}
       editorConfig={{
         valid_elements: validEditorTags,
-        toolbar:
-          "blocks | bold italic | bullist numlist | outdent indent | undo redo",
-        block_formats: "Paragraph=p; Header 1=h1; Header 2=h2; Header 3=h3",
+        toolbar: toolBar,
         ...editorConfig,
       }}
     />

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/I18nRichInputField/index.js
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/I18nRichInputField/index.js
@@ -1,1 +1,2 @@
 export * from "./I18nRichInputField";
+export * from "./OarepoRichEditor";


### PR DESCRIPTION
The PR to fix the problem with abstract field. I have followed the solution used in react-invenio-forms https://github.com/inveniosoftware/react-invenio-forms/blob/42b93636be95177f1d7845e4f55c8bb63a1d9b92/src/lib/forms/RichInputField.js#L16

![image](https://github.com/user-attachments/assets/39714f31-ec95-4395-a04d-04d48161012a)


Which is a hacky solution and causes console errors, as this prop is not supposed to be a function. It even causes an uncaught type error, as the library inside tries to strip white text from the value. This amazingly does not crash the app (i don't understand why). This is screenshot from zenodoo (live):

![image](https://github.com/user-attachments/assets/05377b36-5ef0-4d09-8746-0cd498a802b6)

On the other hand, the problem is deeper as it is not recommended to make the editor actual controlled input, which is the paradigm that we use and is used most often in react (https://www.tiny.cloud/docs/tinymce/latest/react-ref/#using-the-tinymce-react-component-as-a-controlled-component). 

To summarize, it works, but it is not pretty and I don't like it. Alternative would be to make it actual controlled input with onChange handler, which could be inefficient in case someone writes a lot of text into the input.

Please take a look. If it is ok, I can use this component in restauration repo as well.