### PR TITLE
expanding record on detail

### DIFF
--- a/oarepo_ui/resources/config.py
+++ b/oarepo_ui/resources/config.py
@@ -92,6 +92,9 @@ class RecordsUIResourceConfig(UIResourceConfig):
     request_export_args = {"export_format": ma.fields.Str()}
     request_search_args = {"page": ma.fields.Integer(), "size": ma.fields.Integer()}
     request_create_args = {"community": ma.fields.Str()}
+    request_extra_args = {
+        "expand": ma.fields.Boolean(),
+    }
 
     app_contexts = None
     ui_serializer = None

--- a/oarepo_ui/resources/config.py
+++ b/oarepo_ui/resources/config.py
@@ -92,9 +92,6 @@ class RecordsUIResourceConfig(UIResourceConfig):
     request_export_args = {"export_format": ma.fields.Str()}
     request_search_args = {"page": ma.fields.Integer(), "size": ma.fields.Integer()}
     request_create_args = {"community": ma.fields.Str()}
-    request_extra_args = {
-        "expand": ma.fields.Boolean(),
-    }
 
     app_contexts = None
     ui_serializer = None

--- a/oarepo_ui/resources/resource.py
+++ b/oarepo_ui/resources/resource.py
@@ -24,6 +24,7 @@ from invenio_records_resources.resources.records.resource import (
     request_read_args,
     request_search_args,
     request_view_args,
+    request_extra_args,
 )
 from invenio_records_resources.services import LinksTemplate
 from oarepo_runtime.datastreams.utils import get_file_service_for_record_class
@@ -60,7 +61,6 @@ request_create_args = request_parser(from_conf("request_create_args"), location=
 
 
 class UIComponentsMixin:
-
     #
     # Pluggable components
     #
@@ -188,6 +188,7 @@ class RecordsUIResource(UIResource):
     # helper function to avoid duplicating code between detail and preview handler
     @request_read_args
     @request_view_args
+    @request_extra_args
     @response_header_signposting
     def _detail(self, *, is_preview=False):
         if is_preview:
@@ -260,10 +261,14 @@ class RecordsUIResource(UIResource):
             "is_preview": is_preview,
         }
 
-        response = Response(current_oarepo_ui.catalog.render(
-            render_method,
-            **render_kwargs,
-        ), mimetype="text/html", status=200)
+        response = Response(
+            current_oarepo_ui.catalog.render(
+                render_method,
+                **render_kwargs,
+            ),
+            mimetype="text/html",
+            status=200,
+        )
         response._api_record = api_record
         return response
 
@@ -316,7 +321,11 @@ class RecordsUIResource(UIResource):
             else:
                 read_method = self.api_service.read
 
-            return read_method(g.identity, resource_requestctx.view_args["pid_value"])
+            return read_method(
+                g.identity,
+                resource_requestctx.view_args["pid_value"],
+                expand=resource_requestctx.args.get("expand", False),
+            )
         except PermissionDenied as e:
             raise Forbidden() from e
 

--- a/oarepo_ui/resources/resource.py
+++ b/oarepo_ui/resources/resource.py
@@ -24,7 +24,6 @@ from invenio_records_resources.resources.records.resource import (
     request_read_args,
     request_search_args,
     request_view_args,
-    request_extra_args,
 )
 from invenio_records_resources.services import LinksTemplate
 from oarepo_runtime.datastreams.utils import get_file_service_for_record_class
@@ -188,7 +187,6 @@ class RecordsUIResource(UIResource):
     # helper function to avoid duplicating code between detail and preview handler
     @request_read_args
     @request_view_args
-    @request_extra_args
     @response_header_signposting
     def _detail(self, *, is_preview=False):
         if is_preview:
@@ -324,7 +322,7 @@ class RecordsUIResource(UIResource):
             return read_method(
                 g.identity,
                 resource_requestctx.view_args["pid_value"],
-                expand=resource_requestctx.args.get("expand", False),
+                expand=True,
             )
         except PermissionDenied as e:
             raise Forbidden() from e

--- a/oarepo_ui/templates/components/IdentifiersAndLinks.jinja
+++ b/oarepo_ui/templates/components/IdentifiersAndLinks.jinja
@@ -1,5 +1,6 @@
 {# def originalRecordUrl=None, objectIdentifiers=None #}
 
+{% if objectIdentifiers|length > 0 or originalRecordUrl %}
 <section aria-label='{{ _("Identifiers and links") }}' class="ui segment identifiers-and-links">
   <h2 class="ui small header detail-sidebar-header">{{_('Identifiers and links')}}</h2>
   <div class="ui link list">
@@ -52,3 +53,5 @@
     {% endif %}
    </div>
 </section>
+{% endif %}
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-ui
-version = 5.2.14
+version = 5.2.15
 description = UI module for invenio 3.5+
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -9,10 +9,11 @@ def test_edit(
         assert json.loads(c.text) == {
             "api_record": simple_record.id,
             "data": {
+                "expanded": {},
                 "links": {
                     "self": f"https://127.0.0.1:5000/api/simple-model/{simple_record.id}",
                     "ui": f"https://127.0.0.1:5000/simple-model/{simple_record.id}",
-                }
+                },
             },
             "extra_context": {
                 "permissions": {


### PR DESCRIPTION
Expanding the record on detail page, so that requestTypes (applicable requests) and any requests, would return as part of the record, so that we have based on what to render or not the box with actions. Currently, the empty box would also display which is ugly.