### PR TITLE
possible to not show links in community selector:

### DIFF
--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/CommunitySelector/CommunityItem.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/CommunitySelector/CommunityItem.jsx
@@ -4,13 +4,14 @@ import Overridable from "react-overridable";
 import PropTypes from "prop-types";
 import { Image } from "react-invenio-forms";
 
-export const CommunityItem = ({ community, handleClick }) => {
+export const CommunityItem = ({ community, handleClick, renderLinks }) => {
   const { id, title, website, logo, organizations } = community;
   return (
     <Overridable
       id="record-community-selection-item"
       community={community}
       handleClick={handleClick}
+      renderLinks={renderLinks}
     >
       <List.Item
         onClick={() => handleClick(id)}
@@ -21,16 +22,22 @@ export const CommunityItem = ({ community, handleClick }) => {
         </div>
         <List.Content>
           <Header size="small">
-            <a
-              onClick={(e) => e.stopPropagation()}
-              href={community.links.self_html}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {title}
-            </a>
+            {renderLinks ? (
+              <a
+                onClick={(e) => {
+                  e.stopPropagation();
+                }}
+                href={community.links.self_html}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {title}
+              </a>
+            ) : (
+              title
+            )}
           </Header>
-          {website && (
+          {website && renderLinks && (
             <React.Fragment>
               <Icon name="linkify" />
               <a
@@ -58,4 +65,9 @@ export const CommunityItem = ({ community, handleClick }) => {
 CommunityItem.propTypes = {
   community: PropTypes.object.isRequired,
   handleClick: PropTypes.func,
+  renderLinks: PropTypes.bool,
+};
+
+CommunityItem.defaultProps = {
+  renderLinks: true,
 };

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/CommunitySelector/CommunitySelector.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/CommunitySelector/CommunitySelector.jsx
@@ -80,6 +80,7 @@ export const CommunitySelector = ({ fieldPath }) => {
                       key={c.id}
                       community={c}
                       handleClick={handleClick}
+                      renderLinks={false}
                     />
                   ))}
                 </List>
@@ -97,6 +98,7 @@ export const CommunitySelector = ({ fieldPath }) => {
                   <CommunityItem
                     community={generic_community}
                     handleClick={handleClick}
+                    renderLinks={false}
                   />
                 </List>
               </React.Fragment>


### PR DESCRIPTION
After playing with the component for a while, I agree that it can be annoying for the user if they wish to select the community to be taken elsewhere. It can be even worse if community name is long.

In the PR I have removed links all together from the selector, because I simply don't think it makes sense to show for example link to the community website, if you are unable to click on it. I think it would be confusing and misleading to have it there. Please take a look and let me know what you think. Thanks!