### PR TITLE
added helpers for making api calls

### DIFF
--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/util.js
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/util.js
@@ -276,7 +276,17 @@ export const goBack = (fallBackURL = "/") => {
 };
 
 // until we start using v4 of react-invenio-forms. They switched to vnd zenodo accept header
-const baseAxiosConfiguration = {
+const baseAxiosConfigurationApplicationJson = {
+  withCredentials: true,
+  xsrfCookieName: "csrftoken",
+  xsrfHeaderName: "X-CSRFToken",
+  headers: {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+  },
+};
+
+const baseAxiosConfigurationVnd = {
   withCredentials: true,
   xsrfCookieName: "csrftoken",
   xsrfHeaderName: "X-CSRFToken",
@@ -286,7 +296,11 @@ const baseAxiosConfiguration = {
   },
 };
 
-export const http = axios.create(baseAxiosConfiguration);
+export const httpApplicationJson = axios.create(
+  baseAxiosConfigurationApplicationJson
+);
+
+export const httpVnd = axios.create(baseAxiosConfigurationVnd);
 
 export const encodeUnicodeBase64 = (str) => {
   return btoa(encodeURIComponent(str));

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-ui
-version = 5.2.26
+version = 5.2.27
 description = UI module for invenio 3.5+
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
We were using http helper from react-invenio-forms, to make API calls (https://github.com/inveniosoftware/react-invenio-forms/blob/f6ac055fc704c744561687c8a2f77925abd0ecd4/src/lib/api/connector.js#L22)

Currently, (v4 of react-invenio-forms), it is calling to VND api, but we are still on v3 in which it used to call to application-json. 

Unfortunately, due to various reasons, we have inconsistencies on our end as well (some apis dont work, or don't work fully with vnd accept header), so therefore (currently specifically in oarepo-requests, but probably elsewhere as well), we sometimes need to call to application/json and sometimes to vnd. So I thought for safety to simply create two helpers and put them in our code, so we don't get a situation where dependencies upgrade and we end up with broken code. Of course, if we ever manage to get to a point where we can just use vnd header everywhere, we could just delete these and go back to react-invenio-forms helper (which generally I feel is a convenient little abstraction).