### PR TITLE
feat(jinja): webpack_optional global helper

### DIFF
--- a/oarepo_ui/ext.py
+++ b/oarepo_ui/ext.py
@@ -36,7 +36,7 @@ class OARepoUIState:
         try:
             del self.catalog  # noqa - this is a documented method of clearing the cache
         except (
-                AttributeError
+            AttributeError
         ):  # but does not work if the cache is not initialized yet, thus the try/except
             pass
 

--- a/oarepo_ui/proxies.py
+++ b/oarepo_ui/proxies.py
@@ -3,3 +3,6 @@ from werkzeug.local import LocalProxy
 
 current_oarepo_ui = LocalProxy(lambda: current_app.extensions["oarepo_ui"])
 """Proxy to the oarepo_ui state."""
+
+current_optional_manifest = LocalProxy(lambda: current_oarepo_ui.optional_manifest)
+"""Proxy to current optional webpack manifest."""

--- a/oarepo_ui/templates/oarepo_ui/javascript.html
+++ b/oarepo_ui/templates/oarepo_ui/javascript.html
@@ -1,7 +1,6 @@
 {% include "invenio_theme/javascript.html" %}
-
+{{ webpack['oarepo-overridable-registry.js'] }}
 {{ webpack['oarepo_ui_theme.js'] }}
 {{ webpack['oarepo_ui_components.js'] }}
-{{ webpack['oarepo-overridable-registry.js'] }}
 
-
+{{ webpack_optional('overrides-' ~ request.endpoint ~ '.js') }}


### PR DESCRIPTION
This allows for optional inclusion of webpack manifest:

```jinja
{{ webpack_optional('myentry') }}
```

If requested manifest not found in manifest.json, no hard error is raised.
Instead, error gets just output to resulting markup as a plain comment:

<img width="521" alt="Screenshot 2025-01-21 at 17 14 53" src="https://github.com/user-attachments/assets/f6378bf4-84da-4b2a-8b06-d6fa3e2fa5d1" />
