### PR TITLE
fix(overrides): make global search overrides backwards-compatible & robust

### DIFF
--- a/oarepo_ui/ext.py
+++ b/oarepo_ui/ext.py
@@ -110,17 +110,13 @@ class OARepoUIState:
         except ImportError:
             return current_app.config.get("UI_OVERRIDES", {})
 
-        models = current_global_search.model_services
+        global_search_config = current_global_search.global_search_ui_resource.config
 
         global_search_result_items = {}
 
-        for model in models:
-            global_search_result_items[model.record_cls.schema.value] = UIComponent(
-                f"{model.config.service_id.capitalize()}ResultsListItem",
-                # Model Service ID should correspond to generated JS component file import path.
-                f"@js/{model.config.service_id}/search/ResultsListItem",
-                "default",
-            )
+        for schema, search_component in global_search_config.default_components.items():
+            if isinstance(search_component, UIComponent):
+                global_search_result_items[schema] = search_component
 
         def _global_search_ui(app_name):
             return {

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-ui
-version = 5.2.46
+version = 5.2.48
 description = UI module for invenio 3.5+
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Uses already present default search components as registered by Record UI resource config under `search_component` to determine, which overrides are needed for global search UI. If `search_component` is string, it does nothing (fallbacks to legacy template-based approach to load overrides)