### PR TITLE
calling get field data on top level

### DIFF
--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/NestedErrors/NestedErrors.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/NestedErrors/NestedErrors.jsx
@@ -3,6 +3,16 @@ import { useFormikContext, getIn } from "formik";
 import { Label } from "semantic-ui-react";
 import { useFieldData } from "@js/oarepo_ui";
 import PropTypes from "prop-types";
+// getfielddata must only be called on top level of component because it uses useMemo
+const ErrorMessageItem = ({ error }) => {
+  const { getFieldData } = useFieldData();
+  const label = getFieldData({
+    fieldPath: error.errorPath,
+    fieldRepresentation: "text",
+  })?.label;
+
+  return `${label}: ${error.errorMessage}`;
+};
 
 export const NestedErrors = ({ fieldPath }) => {
   const { errors } = useFormikContext();
@@ -17,20 +27,15 @@ export const NestedErrors = ({ fieldPath }) => {
       errorPath,
     };
   });
-  const { getFieldData } = useFieldData();
 
   return (
     nestedErrors?.length > 0 && (
       <React.Fragment>
         <Label className="rel-mb-1 mt-0" prompt pointing="above">
-          {nestedErrors.map(({ errorMessage, errorPath }, index) => (
-            <p key={errorPath}>{`${
-              getFieldData({
-                fieldPath: errorPath,
-                fieldRepresentation: "text",
-                ignorePrefix: true,
-              }).label
-            }: ${errorMessage}`}</p>
+          {nestedErrors.map((nestedError, index) => (
+            <p key={nestedError.errorPath}>
+              <ErrorMessageItem error={nestedError} />
+            </p>
           ))}
         </Label>
         <br />


### PR DESCRIPTION
getFieldData must be called on top level of a component always, because it uses useMemo to memoize the results.