### PR TITLE
fix: added possibility to manually pass error to language field

### DIFF
--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/I18nTextInputField/I18nTextInputField.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/I18nTextInputField/I18nTextInputField.jsx
@@ -12,6 +12,7 @@ export const I18nTextInputField = ({
   fieldPath,
   optimized,
   lngFieldWidth,
+  lngFieldError,
   usedLanguages,
   ...uiProps
 }) => {
@@ -33,6 +34,7 @@ export const I18nTextInputField = ({
           icon: "globe",
           fieldRepresentation: "compact",
         })}
+        error={lngFieldError}
       />
       <TextField
         fieldPath={textFieldPath}


### PR DESCRIPTION
Unfortunately, in some fields, like additional titles field, you have title that is required, and title is an object where you have {lang:"lngcode", value: "string"} , and if title is required, you don't get errors on sub fields to display at the correct inputs, by how normally errors are taken from the errors object, so this would allow you to pass the error manually to the language field too. It is one off solution to be able to fix https://linear.app/ducesnet/issue/NTK-213/vkladaci-formulardalsi-nazvy

Related issues

https://github.com/Narodni-repozitar/nr-model/pull/123
https://github.com/Narodni-repozitar/nr-docs/pull/384
https://github.com/oarepo/oarepo-runtime/pull/318/files