### PR TITLE
Migrate Webpack/RSpack to UIComponentOverrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -380,3 +380,5 @@ vite.config.ts.timestamp-*
 .DS_Store
 *.DS_Store?
 #
+
+.invenio.private

--- a/.invenio
+++ b/.invenio
@@ -1,0 +1,2 @@
+[cli]
+flavour = RDM

--- a/oarepo_ui/ext.py
+++ b/oarepo_ui/ext.py
@@ -136,7 +136,7 @@ class OARepoUIState:
         """Get the UI overrides for the current app."""
         return cast("set[UIComponentOverride]", current_app.config.get("OAREPO_UI_OVERRIDES", {}))
 
-    @cached_property
+    @property
     def ui_overrides_by_endpoint(self) -> dict[str, set[UIComponentOverride]]:
         """Get the UI overrides for the app, grouped by Flask Blueprint endpoint."""
         endpoint_overrides: dict[str, set[UIComponentOverride]] = defaultdict(set)

--- a/oarepo_ui/ext.py
+++ b/oarepo_ui/ext.py
@@ -15,9 +15,9 @@ catalog configuration, resource registration, and UI component overrides.
 
 from __future__ import annotations
 
-from collections import defaultdict
 import contextlib
 import warnings
+from collections import defaultdict
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, cast
 
@@ -140,7 +140,7 @@ class OARepoUIState:
     def ui_overrides_by_endpoint(self) -> dict[str, set[UIComponentOverride]]:
         """Get the UI overrides for the app, grouped by Flask Blueprint endpoint."""
         endpoint_overrides: dict[str, set[UIComponentOverride]] = defaultdict(set)
-        
+
         for component_override in self.ui_overrides:
             endpoint_overrides[component_override.endpoint].add(component_override)
 
@@ -158,7 +158,6 @@ class OARepoUIState:
         with self.app.app_context():
             for registration_callback in self.app.config.get("OAREPO_UI_RESULT_LIST_ITEM_REGISTRATION_CALLBACK", []):
                 if callable(registration_callback):
-                    print(registration_callback)
                     registration_callback(self.ui_overrides, schema, component)
                 else:
                     raise TypeError(f"Registration callback {registration_callback} is not callable.")

--- a/oarepo_ui/proxies.py
+++ b/oarepo_ui/proxies.py
@@ -21,9 +21,12 @@ from flask import current_app
 from werkzeug.local import LocalProxy
 
 if TYPE_CHECKING:
+    from oarepo_ui.ui.components import UIComponentOverride
+
     from .ext import OARepoUIState
 
     current_oarepo_ui: OARepoUIState
+    current_ui_overrides: set[UIComponentOverride]
 
 current_oarepo_ui = LocalProxy(lambda: current_app.extensions["oarepo_ui"])  # type: ignore[assignment]
 """Proxy to the oarepo_ui state."""

--- a/oarepo_ui/proxies.py
+++ b/oarepo_ui/proxies.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 current_oarepo_ui = LocalProxy(lambda: current_app.extensions["oarepo_ui"])  # type: ignore[assignment]
 """Proxy to the oarepo_ui state."""
 
-current_ui_overrides = LocalProxy(lambda: current_app.extensions["oarepo_ui"].ui_overrides)
+current_ui_overrides = LocalProxy(lambda: current_app.extensions["oarepo_ui"].ui_overrides)  # type: ignore[assignment]
 """Proxy to get the current ui_overrides."""
 
 current_optional_manifest = LocalProxy(lambda: current_oarepo_ui.optional_manifest)

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/components/IdentifierBadge.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/components/IdentifierBadge.jsx
@@ -2,12 +2,38 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Image } from "react-invenio-forms";
 
+/**
+ * IconIdentifier renders an identifier icon, optionally wrapped in an anchor link.
+ *
+ * Typically used to display provider or authority icons (e.g., ORCID, DOI).
+ * If a `link` is provided, the icon becomes a clickable external link.
+ */
 export const IconIdentifier = ({
+  /**
+   * Optional external URL. If provided, the icon will be wrapped
+   * in an anchor tag that opens in a new tab.
+   */
   link,
+  /**
+   * Tooltip and accessibility label for the icon.
+   * Appears as the `title` attribute on the element.
+   */
   badgeTitle = "",
+  /**
+   * Path or URL to the icon image.
+   */
   icon,
+  /**
+   * Alternative text for the icon (for screen readers).
+   */
   alt = "",
+  /**
+   * Additional CSS classes applied to the wrapper element.
+   */
   className = "",
+  /**
+   * Fallback image path if the provided icon fails to load.
+   */
   fallbackImage = "/static/images/square-placeholder.png",
 }) => {
   return link ? (
@@ -44,18 +70,50 @@ export const IconIdentifier = ({
 
 /* eslint-disable react/require-default-props */
 IconIdentifier.propTypes = {
+  /** Optional external URL for the identifier. */
   link: PropTypes.string,
+  /** Tooltip and accessibility label for the icon. */
   badgeTitle: PropTypes.string,
+  /** Path or URL to the icon image. */
   icon: PropTypes.string,
+  /** Alternative text for the icon image. */
   alt: PropTypes.string,
+  /** Additional CSS classes. */
   className: PropTypes.string,
+  /** Fallback image if the main icon fails to load. */
   fallbackImage: PropTypes.string,
 };
 /* eslint-enable react/require-default-props */
 
+/**
+ * IdentifierBadge renders an identifier badge for a "creatibutor"
+ * (creator or contributor).
+ *
+ * It combines scheme, identifier value, and optional name into
+ * a descriptive tooltip, and automatically resolves the icon
+ * from `/static/images/identifiers/{scheme}.svg`.
+ */
 export const IdentifierBadge = ({
+  /**
+   * Identifier object containing scheme, value, and optional URL.
+   * Example:
+   * ```js
+   * {
+   *   scheme: "orcid",
+   *   identifier: "0000-0002-1825-0097",
+   *   url: "https://orcid.org/0000-0002-1825-0097"
+   * }
+   * ```
+   */
   identifier,
+  /**
+   * Optional name of the creatibutor (creator/contributor).
+   * Included in the tooltip (e.g., "Alice ORCID: 0000-0002-1825-0097").
+   */
   creatibutorName = "",
+  /**
+   * Additional CSS classes applied to the badge wrapper.
+   */
   className = "",
 }) => {
   const { scheme, identifier: identifierValue, url } = identifier;
@@ -76,13 +134,14 @@ export const IdentifierBadge = ({
 };
 
 IdentifierBadge.propTypes = {
+  /** Identifier object with scheme, value, and URL. */
   identifier: PropTypes.shape({
     scheme: PropTypes.string,
     identifier: PropTypes.string,
     url: PropTypes.string,
   }).isRequired,
-  // eslint-disable-next-line react/require-default-props
+  /** Additional CSS classes applied to the wrapper. */
   className: PropTypes.string,
-  // eslint-disable-next-line react/require-default-props
+  /** Optional creatibutor (author/contributor) name. */
   creatibutorName: PropTypes.string,
 };

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/components/IdentifierBadge.stories.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/components/IdentifierBadge.stories.jsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { IdentifierBadge, IconIdentifier } from "./IdentifierBadge";
+
+export default {
+  title: "Components/IdentifierBadge",
+  component: IdentifierBadge,
+  tags: ["autodocs"], // Storybook 9 autodocs
+  args: {
+    className: "",
+  },
+};
+
+const exampleIdentifier = {
+  scheme: "orcid",
+  identifier: "0000-0002-1825-0097",
+  url: "https://orcid.org/0000-0002-1825-0097",
+};
+
+// ---------- IdentifierBadge stories ----------
+
+export const Default = {
+  args: {
+    identifier: exampleIdentifier,
+    creatibutorName: "Jane Doe",
+  },
+};
+
+export const WithoutLink = {
+  args: {
+    identifier: {
+      ...exampleIdentifier,
+      url: null, // no link, falls back to span + image
+    },
+    creatibutorName: "Jane Doe",
+  },
+};
+
+export const WithDifferentScheme = {
+  args: {
+    identifier: {
+      scheme: "ror",
+      identifier: "050dkka69",
+      url: "https://ror.org/050dkka69",
+    },
+    creatibutorName: "CESNET a.l.e.",
+  },
+};
+
+export const BrokenIcon = {
+  args: {
+    identifier: {
+      scheme: "nonexistent", // image won't exist
+      identifier: "some-id",
+      url: "https://example.com",
+    },
+    creatibutorName: "Fallback Example",
+  },
+};
+
+// ---------- IconIdentifier stories (direct) ----------
+
+export const IconOnly = {
+  render: (args) => <IconIdentifier {...args} />,
+  args: {
+    link: "https://example.com",
+    badgeTitle: "Custom Icon",
+    icon: "/static/images/identifiers/orcid.svg",
+    alt: "ORCID logo",
+  },
+};
+
+export const IconWithoutLink = {
+  render: (args) => <IconIdentifier {...args} />,
+  args: {
+    badgeTitle: "No Link Example",
+    icon: "/static/images/identifiers/orcid.svg",
+    alt: "ORCID logo",
+  },
+};

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/components/IdentifierBadge.stories.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/components/IdentifierBadge.stories.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { expect } from "@storybook/test";
 import { IdentifierBadge, IconIdentifier } from "./IdentifierBadge";
 
 export default {
@@ -22,6 +23,22 @@ export const Default = {
   args: {
     identifier: exampleIdentifier,
     creatibutorName: "Jane Doe",
+  },
+  play: async ({ canvas, userEvent }) => {
+
+    // Wait for the image to appear
+    await expect(canvas.findByRole('img', { name: /ORCID/i })).toBeInTheDocument();
+
+    // Wait for the badge text
+    const badge = await canvas.findByText(/ORCID/i);
+    await expect(badge).toBeVisible();
+
+    // Try clicking the link wrapper
+    const link = img.closest('a');
+    await expect(link).toHaveAttribute('href', 'https://orcid.org/0000-0002-1825-0097');
+
+    // Simulate user clicking the link
+    await userEvent.click(link);
   },
 };
 

--- a/oarepo_ui/ui/components.py
+++ b/oarepo_ui/ui/components.py
@@ -84,7 +84,7 @@ class UIComponent:
 class UIComponentOverride:
     """Represents an override for a UI component.
 
-    An instance of this class should be placed to UI_OVERRIDES configuration
+    An instance of this class should be placed to OAREPO_UI_OVERRIDES configuration
     (set of UIComponentOverride instances).
 
     To minimize bundle size, Javascript overrides are packaged in a way that they apply
@@ -93,8 +93,11 @@ class UIComponentOverride:
     """
 
     endpoint: str
+    """Flask Blueprint endpoint name."""
     overridable_id: str
+    """Unique overridable component ID for react-overridable."""
     component: UIComponent
+    """UI component module description."""
 
     @override
     def __eq__(self, other: object) -> bool:

--- a/oarepo_ui/views.py
+++ b/oarepo_ui/views.py
@@ -60,3 +60,6 @@ def finalize_app(app: Flask) -> None:
         # hide the /admin (maximum recursion depth exceeded menu)
         admin_menu = current_menu.submenu("settings.admin")
         admin_menu.hide()
+
+        # Override webpack/rspack project from invenio-assets
+        app.config["WEBPACKEXT_PROJECT"] = "oarepo_ui.webpack:project"

--- a/oarepo_ui/webpack.py
+++ b/oarepo_ui/webpack.py
@@ -58,7 +58,7 @@ class OverridableBundleProject(WebpackBundleProject):
         config: dict[str, Any] | None = None,
         config_path: str | None = None,
         overrides_bundle_path: str = "_overrides",
-        **kwargs
+        **kwargs: dict[str, Any],
     ) -> None:
         """Initialize templated folder.
 
@@ -92,7 +92,7 @@ class OverridableBundleProject(WebpackBundleProject):
             bundles=bundles,
             config=config,
             config_path=config_path,
-            **kwargs
+            **kwargs,
         )
         self._overrides_bundle_path = Path(overrides_bundle_path)
         self._generated_paths: list[str] = []

--- a/oarepo_ui/webpack.py
+++ b/oarepo_ui/webpack.py
@@ -23,11 +23,10 @@ from flask_webpackext import WebpackBundleProject
 from pywebpack import bundles_from_entry_point
 from pywebpack.helpers import cached
 
-from .proxies import current_ui_overrides, current_oarepo_ui
+from .proxies import current_oarepo_ui, current_ui_overrides
 
 if TYPE_CHECKING:
     from flask_webpackext.bundle import WebpackBundle
-
 
 
 overrides_js_template = """

--- a/oarepo_ui/webpack.py
+++ b/oarepo_ui/webpack.py
@@ -23,29 +23,30 @@ from flask_webpackext import WebpackBundleProject
 from pywebpack import bundles_from_entry_point
 from pywebpack.helpers import cached
 
-from .proxies import current_ui_overrides
+from .proxies import current_ui_overrides, current_oarepo_ui
 
 if TYPE_CHECKING:
     from flask_webpackext.bundle import WebpackBundle
 
+
+
 overrides_js_template = """
 import { overrideStore, parametrize } from 'react-overridable';
 
-{% for key, component in overrides.items() -%}
-{{ component.import_statement | safe }}
+{% for componentOverride in overrides -%}
+{{ componentOverride.component.import_statement | safe }}
 {% endfor %}
 
-{%- for key, component in overrides.items() -%}
-{%- if component.props -%}{{ component.parametrize_statement | safe }}{%- endif -%}
+{%- for componentOverride in overrides -%}
+{%- if componentOverride.component.props -%}{{ componentOverride.component.parametrize_statement | safe }}{%- endif -%}
 {%- endfor %}
 
-{% for key, component in overrides.items() -%}
-overrideStore.add('{{ key }}', {{ component.name }});
+{% for componentOverride in overrides -%}
+overrideStore.add('{{ componentOverride.overridable_id }}', {{ componentOverride.component.name }});
 {% endfor %}
 """
 
 
-# TODO: Convert to rspack?
 class OverridableBundleProject(WebpackBundleProject):
     """A WebpackBundleProject that supports UI overrides and dynamic bundle generation."""
 
@@ -116,8 +117,11 @@ class OverridableBundleProject(WebpackBundleProject):
     def entry(self) -> dict[str, str]:
         """Get webpack entry points."""
         bundle_entries = cast("dict[str, str]", super().entry)
-        for bp_name in current_ui_overrides:
-            bundle_entries[f"overrides-{bp_name}"] = f"./{self.overrides_bundle_asset_path}/{bp_name}.js"
+
+        for component_override in current_ui_overrides:
+            bundle_entries[f"overrides-{component_override.endpoint}"] = (
+                f"./{self.overrides_bundle_asset_path}/{component_override.endpoint}.js"
+            )
         return bundle_entries
 
     @override
@@ -135,10 +139,10 @@ class OverridableBundleProject(WebpackBundleProject):
         if not Path(self.overrides_bundle_path).exists():
             Path(self.overrides_bundle_path).mkdir(parents=True, exist_ok=True)
 
-        for bp_name, overrides in current_ui_overrides.items():
+        for endpoint, component_overrides in current_oarepo_ui.ui_overrides_by_endpoint.items():
             template = current_app.jinja_env.from_string(overrides_js_template)
-            overrides_js_content = template.render({"overrides": overrides})
-            overrides_js_path = Path(self.overrides_bundle_path) / f"{bp_name}.js"
+            overrides_js_content = template.render({"overrides": component_overrides})
+            overrides_js_path = Path(self.overrides_bundle_path) / f"{endpoint}.js"
 
             with overrides_js_path.open("w+") as f:
                 f.write(overrides_js_content)

--- a/oarepo_ui/webpack.py
+++ b/oarepo_ui/webpack.py
@@ -58,6 +58,7 @@ class OverridableBundleProject(WebpackBundleProject):
         config: dict[str, Any] | None = None,
         config_path: str | None = None,
         overrides_bundle_path: str = "_overrides",
+        **kwargs
     ) -> None:
         """Initialize templated folder.
 
@@ -91,6 +92,7 @@ class OverridableBundleProject(WebpackBundleProject):
             bundles=bundles,
             config=config,
             config_path=config_path,
+            **kwargs
         )
         self._overrides_bundle_path = Path(overrides_bundle_path)
         self._generated_paths: list[str] = []
@@ -157,4 +159,5 @@ project = OverridableBundleProject(
     project_folder="assets",
     config_path="build/config.json",
     bundles=cast("list[WebpackBundle]", list(bundles_from_entry_point("invenio_assets.webpack"))),
+    package_json_source_path="rspack-package.json",
 )

--- a/oarepo_ui/webpack.py
+++ b/oarepo_ui/webpack.py
@@ -58,7 +58,7 @@ class OverridableBundleProject(WebpackBundleProject):
         config: dict[str, Any] | None = None,
         config_path: str | None = None,
         overrides_bundle_path: str = "_overrides",
-        **kwargs: dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         """Initialize templated folder.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "frozendict",
     "jinjax>=0.60,<1.0.0",
     "deepmerge>=2.0",
+    "python-dotenv>=1.1.1"
 ]
 requires-python = ">=3.13,<3.14"
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,0 @@
-"""Installation script for the Oarepo UI package."""
-
-from setuptools import setup
-
-setup()

--- a/tests/test_ui_webpack.py
+++ b/tests/test_ui_webpack.py
@@ -8,7 +8,6 @@
 #
 from __future__ import annotations
 
-from contextlib import suppress
 from pathlib import Path
 
 from oarepo_ui.proxies import current_oarepo_ui, current_ui_overrides
@@ -96,10 +95,12 @@ def test_overridable_bundle_project_generated_paths(app):
 
 
 def test_overridable_result_item_registration(app):
+    assert app.extensions["oarepo_ui"].ui_overrides is not None
+    del app.extensions["oarepo_ui"].ui_overrides
+
     app.config["OAREPO_UI_OVERRIDES"] = set()
-    with suppress(AttributeError):
-        # Remove any previous cache
-        del current_oarepo_ui.ui_overrides
+    project.clean()
+    project.create()
 
     def _register_result_item_to_my_ui(
         ui_overrides: set[UIComponentOverride], schema: str, component: UIComponent


### PR DESCRIPTION
Introduces typing to `OAREPO_UI_OVERRIDES` app config.
Instead of a generic dict, it is now a set of `UIComponentOverride(endpoint, overridable_id, component)`, which means:

1) any library can add its component overrides, by just adding it to the set in their `init_config` using similar logic:
```python
    def init_config(self, app: Flask) -> None:
        """Initialize configuration."""
        MyComponent = UIComponent(...)
        override = UIComponentOverride("my-endpoint","ComponentA", MyComponent)
        if override not in current_ui_overrides:
            current_ui_overrides.add(override)
```

2) any model can register its search result item component for use in various search UI's. This should be done in corresponding model's ui resource, e.g.:
```
def create_blueprint(app):
    config = DocumentsUIResourceConfig()
    resource = DocumentsUIResource(config)
    current_oarepo_ui.register_result_list_item(resource.api_config.schema, config.search_component)
    return resource.as_blueprint()
```

3) any library can use search result items registered by models in their own search apps, by registering own callback under `OAREPO_UI_RESULT_LIST_ITEM_REGISTRATION_CALLBACK` app config. Callback func is responsible for creating UIComponentOverride with library-specific endpoint and overridable-id, and adding it to current_ui_overrides
