### PR TITLE
html5backend

### DIFF
--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/TabForm/TabForm.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/TabForm/TabForm.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, useMemo } from "react";
+import React, { useEffect, useCallback, useMemo, useRef } from "react";
 import PropTypes from "prop-types";
 import { Grid, Message } from "semantic-ui-react";
 import { useDispatch, useSelector } from "react-redux";
@@ -36,6 +36,16 @@ export const TabForm = ({ sections = [] }) => {
   const [activeStep, setActiveStepState] = React.useState(
     Math.max(initialStep, 0)
   );
+  const [isTransitioning, setIsTransitioning] = React.useState(false);
+  const transitionTimerRef = useRef(null);
+
+  useEffect(() => {
+    return () => {
+      if (transitionTimerRef.current) {
+        clearTimeout(transitionTimerRef.current);
+      }
+    };
+  }, []);
 
   const { handleAction: handleSave } = useDepositFormAction({
     action: saveAction,
@@ -46,13 +56,21 @@ export const TabForm = ({ sections = [] }) => {
       if (!(index >= 0 && index < sectionKeys.length)) {
         return;
       }
-      setActiveStepState(index);
-      const url = new URL(window.location);
-      url.searchParams.set("tab", sectionKeys[index]);
-      window.history.replaceState({}, "", url);
       if (dirty) {
         handleSave();
       }
+      const url = new URL(window.location);
+      url.searchParams.set("tab", sectionKeys[index]);
+      window.history.replaceState({}, "", url);
+      setIsTransitioning(true);
+      if (transitionTimerRef.current) {
+        clearTimeout(transitionTimerRef.current);
+      }
+      transitionTimerRef.current = setTimeout(() => {
+        transitionTimerRef.current = null;
+        setActiveStepState(index);
+        setIsTransitioning(false);
+      }, 0);
     },
     [sectionKeys, handleSave, dirty]
   );
@@ -183,12 +201,14 @@ export const TabForm = ({ sections = [] }) => {
               className="tab-content-column pl-0 pr-0"
               data-testid="tab-form-content-column"
             >
-              <TabContent
-                activeStep={activeStep}
-                sections={sections}
-                next={next}
-                back={back}
-              />
+              {!isTransitioning && (
+                <TabContent
+                  activeStep={activeStep}
+                  sections={sections}
+                  next={next}
+                  back={back}
+                />
+              )}
             </Grid.Column>
           </Overridable>
         </Grid.Row>


### PR DESCRIPTION
The issue happens, when you have a section that contains element with dnd provider such as creatibutors or licenses, the form is dirty and you switch to another tab that contains input with dnd provider. It seems that cleanup for unmounting runs after the new provider is mounted. Proper solution would be to have one dnd provider wrapping entire form, but this is not possible, because invenio inputs that use this, just wrap components directly with dnd provider. I don't like this solution, but as we cannot change invenio's code, it will have to be solved in some hacky way. Alternative would be to show the loading spinner in the panel content, while the form is submitting, though this introduces more delay in how panel content is displayed. I think this is as reasonable as we can do it, without going into invenio's code, but please let me know in case of better suggestions.