### PR TITLE
fix: using vnd accept header inside of the form

### DIFF
--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/DepositFormApp/DepositFormApp.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/DepositFormApp/DepositFormApp.jsx
@@ -48,7 +48,7 @@ export class DepositFormApp extends Component {
       : {
           "vnd+json": {
             "Content-Type": "application/json",
-            Accept: "application/json",
+            Accept: "application/vnd.inveniordm.v1+json",
           },
         };
 


### PR DESCRIPTION
* now that our files service supports this we can switch to vnd
* accept header and that would enable us to recieve UI key
* in responses when making http calls inside the form