### PR TITLE
Remove workflows extra to fix circular dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,6 @@ tests = [
     "invenio-search>=3.0.0,<4.0.0",
     "pytest-invenio>=4.0.0,<5.0.0",
 ]
-workflows = [
-    "oarepo-workflows",
-]
 oarepo14= [
     "oarepo>=14.0.0,<15.0.0"
 ]


### PR DESCRIPTION
Removes the unused `[workflows]` optional dependency that created a circular dependency chain with oarepo-workflows and oarepo-rdm.

No code in oarepo-ui imports from oarepo_workflows, so this extra was unnecessary. Users who need workflows can still install it separately via `pip install oarepo-workflows`.