### PR TITLE
add possibility to provide summary when hovering tab/step

### DIFF
--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/FormSteps/FormSteps.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/FormSteps/FormSteps.jsx
@@ -1,8 +1,73 @@
 import React, { useRef, useEffect } from "react";
 import PropTypes from "prop-types";
-import { Step } from "semantic-ui-react";
+import { Step, Popup } from "semantic-ui-react";
+import { useFormikContext } from "formik";
 import { FormTabErrors } from "../FormTabErrors";
 import { useFormNavigation } from "../../hooks";
+
+const FormStepItem = ({
+  section,
+  index,
+  isActive,
+  hasBeenSavedInSession,
+  handleClick,
+  handleKeyDown,
+  activeStep,
+}) => {
+  const { values } = useFormikContext();
+  const summaryContent = section.summary?.(values);
+
+  const step = (
+    <Step
+      id={`form-step-${section.key}`}
+      active={isActive(index)}
+      completed={index < activeStep}
+      onClick={() => handleClick(index)}
+      onKeyDown={(event) => handleKeyDown(event, index)}
+      link
+      role="tab"
+      aria-selected={isActive(index)}
+      tabIndex={isActive(index) ? 0 : -1}
+      data-testid={`form-step-${section.key}`}
+    >
+      <Step.Content>
+        <Step.Title>
+          {hasBeenSavedInSession && (
+            <FormTabErrors includesPaths={section.includesPaths || []} />
+          )}
+          {section.label}
+        </Step.Title>
+      </Step.Content>
+    </Step>
+  );
+
+  if (!summaryContent) return step;
+
+  return (
+    <Popup
+      trigger={step}
+      content={summaryContent}
+      position="bottom center"
+      size="small"
+      mouseEnterDelay={300}
+    />
+  );
+};
+
+FormStepItem.propTypes = {
+  section: PropTypes.shape({
+    key: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+    includesPaths: PropTypes.array,
+    summary: PropTypes.func,
+  }).isRequired,
+  index: PropTypes.number.isRequired,
+  isActive: PropTypes.func.isRequired,
+  hasBeenSavedInSession: PropTypes.bool.isRequired,
+  handleClick: PropTypes.func.isRequired,
+  handleKeyDown: PropTypes.func.isRequired,
+  activeStep: PropTypes.number.isRequired,
+};
 
 export const FormSteps = ({ sections, activeStep, onTabChange }) => {
   const scrollContainerRef = useRef(null);
@@ -46,28 +111,16 @@ export const FormSteps = ({ sections, activeStep, onTabChange }) => {
         data-testid="form-steps"
       >
         {sections.map((section, index) => (
-          <Step
-            id={`form-step-${section.key}`}
+          <FormStepItem
             key={section.key}
-            active={isActive(index)}
-            completed={index < activeStep}
-            onClick={() => handleClick(index)}
-            onKeyDown={(event) => handleKeyDown(event, index)}
-            link
-            role="tab"
-            aria-selected={isActive(index)}
-            tabIndex={isActive(index) ? 0 : -1}
-            data-testid={`form-step-${section.key}`}
-          >
-            <Step.Content>
-              <Step.Title>
-                {hasBeenSavedInSession && (
-                  <FormTabErrors includesPaths={section.includesPaths || []} />
-                )}
-                {section.label}
-              </Step.Title>
-            </Step.Content>
-          </Step>
+            section={section}
+            index={index}
+            isActive={isActive}
+            hasBeenSavedInSession={hasBeenSavedInSession}
+            handleClick={handleClick}
+            handleKeyDown={handleKeyDown}
+            activeStep={activeStep}
+          />
         ))}
       </Step.Group>
     </div>
@@ -81,6 +134,8 @@ FormSteps.propTypes = {
       label: PropTypes.string.isRequired,
       includesPaths: PropTypes.array,
       saveOnTabChange: PropTypes.bool,
+      /** (values) => string|ReactNode|null — optional summary shown in a tooltip on hover */
+      summary: PropTypes.func,
       /** component({ record, formConfig, activeStep, next, back, initialRecord }) => ReactNode */
       component: PropTypes.func.isRequired,
     })

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/FormTabs/FormTabs.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/FormTabs/FormTabs.jsx
@@ -1,8 +1,71 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Menu, Icon } from "semantic-ui-react";
+import { Menu, Icon, Popup } from "semantic-ui-react";
+import { useFormikContext } from "formik";
 import { FormTabErrors } from "../FormTabErrors";
 import { useFormNavigation } from "../../hooks";
+
+const FormTabItem = ({
+  section,
+  index,
+  isActive,
+  hasBeenSavedInSession,
+  handleClick,
+  handleKeyDown,
+}) => {
+  const { values } = useFormikContext();
+  const summaryContent = section.summary?.(values);
+
+  const menuItem = (
+    <Menu.Item
+      id={`form-tab-${section.key}`}
+      as="a"
+      onClick={() => handleClick(index)}
+      onKeyDown={(event) => handleKeyDown(event, index)}
+      active={isActive(index)}
+      role="tab"
+      aria-selected={isActive(index)}
+      tabIndex={isActive(index) ? 0 : -1}
+      data-testid={`form-tab-${section.key}`}
+    >
+      <div className="flex">
+        {hasBeenSavedInSession && (
+          <FormTabErrors includesPaths={section.includesPaths || []} />
+        )}
+        {section.label}
+      </div>
+      <div>
+        <Icon name="chevron right" />
+      </div>
+    </Menu.Item>
+  );
+
+  if (!summaryContent) return menuItem;
+
+  return (
+    <Popup
+      trigger={menuItem}
+      content={summaryContent}
+      position="right center"
+      size="small"
+      mouseEnterDelay={300}
+    />
+  );
+};
+
+FormTabItem.propTypes = {
+  section: PropTypes.shape({
+    key: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+    includesPaths: PropTypes.array,
+    summary: PropTypes.func,
+  }).isRequired,
+  index: PropTypes.number.isRequired,
+  isActive: PropTypes.func.isRequired,
+  hasBeenSavedInSession: PropTypes.bool.isRequired,
+  handleClick: PropTypes.func.isRequired,
+  handleKeyDown: PropTypes.func.isRequired,
+};
 
 export const FormTabs = ({ sections, activeStep, onTabChange }) => {
   const { hasBeenSavedInSession, isActive, handleClick, handleKeyDown } =
@@ -21,28 +84,15 @@ export const FormTabs = ({ sections, activeStep, onTabChange }) => {
       data-testid="form-tabs"
     >
       {sections.map((section, index) => (
-        <Menu.Item
-          id={`form-tab-${section.key}`}
-          as="a"
+        <FormTabItem
           key={section.key}
-          onClick={() => handleClick(index)}
-          onKeyDown={(event) => handleKeyDown(event, index)}
-          active={isActive(index)}
-          role="tab"
-          aria-selected={isActive(index)}
-          tabIndex={isActive(index) ? 0 : -1}
-          data-testid={`form-tab-${section.key}`}
-        >
-          <div className="flex">
-            {hasBeenSavedInSession && (
-              <FormTabErrors includesPaths={section.includesPaths || []} />
-            )}
-            {section.label}
-          </div>
-          <div>
-            <Icon name="chevron right" />
-          </div>
-        </Menu.Item>
+          section={section}
+          index={index}
+          isActive={isActive}
+          hasBeenSavedInSession={hasBeenSavedInSession}
+          handleClick={handleClick}
+          handleKeyDown={handleKeyDown}
+        />
       ))}
     </Menu>
   );
@@ -55,6 +105,8 @@ FormTabs.propTypes = {
       label: PropTypes.string.isRequired,
       includesPaths: PropTypes.array,
       saveOnTabChange: PropTypes.bool,
+      /** (values) => string|ReactNode|null — optional summary shown in a tooltip on hover */
+      summary: PropTypes.func,
       /** component({ record, formConfig, activeStep, next, back, initialRecord }) => ReactNode */
       component: PropTypes.func.isRequired,
     })


### PR DESCRIPTION
A prototype of how summary of tabs could be made. Not sure for now if it is a good idea at all tbh. If we put it into the step/tab itself, theb it bloats the layout. If we put it in the popup, then I guess it could be a bit annoying. Worth discussing additionally. Also, given the big difference in content of tabs, you would need always some custom function to dig through the metadata to select what you want to display.