### PR TITLE
[breaking] fix: using our own head links

### DIFF
--- a/oarepo_ui/templates/oarepo_ui/base_page.html
+++ b/oarepo_ui/templates/oarepo_ui/base_page.html
@@ -1,5 +1,18 @@
 {% extends "invenio_app_rdm/page.html" %}
 
+{%- block head_links %}
+  <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='oarepo-favicon.svg') }}"/>
+  {%- if keywords %}
+    <link rel="canonical" href="{{ canonical_url }}"/>
+  {% endif %}
+{%- endblock head_links %}
+
+{%- block head_apple_icons %}
+  {%- for size in [120, 152, 167, 180] %}
+    <link rel="apple-touch-icon" sizes="{{ size }}x{{ size }}" href="{{ url_for('static', filename='oarepo-apple-touch-icon-%d.png' | format(size)) }}"/>
+  {%- endfor %}
+{%- endblock head_apple_icons %}
+
 {%- block head %}
 {{ super() }}
 {% if config.MATOMO_ANALYTICS_TEMPLATE %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oarepo-ui"
-version = "10.2.0"
+version = "11.0.0"
 description = "UI module for invenio 3.5+"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Invenio already has these same assets like favicon.ico in their statics somwhere, so when you add your own, your build can (cli assets build) can fail, because that file already exists. I think we should just name these differently, and the users will have to provide their own that are named in such a way. Will add to docs.