### PR TITLE
feat: use ExportEngine for record_detail

### DIFF
--- a/oarepo_ui/resources/decorators/signposting.py
+++ b/oarepo_ui/resources/decorators/signposting.py
@@ -19,7 +19,8 @@ from collections.abc import Callable
 from functools import wraps
 from typing import TYPE_CHECKING, Any
 
-from oarepo_runtime.resources.signposting import record_dict_to_linkset
+from oarepo_runtime.api import ExportEngine
+from oarepo_runtime.resources.signposting import create_linkset
 
 from ..utils import get_api_record_from_response
 
@@ -46,7 +47,12 @@ def response_header_signposting[T: Callable](f: T) -> T:
         api_record = get_api_record_from_response(response)
         if not api_record:
             return response
-        record_linkset = record_dict_to_linkset(api_record.to_dict(), include_reverse_relations=False)
+        record_dict = api_record.to_dict()
+        record_linkset = create_linkset(
+            ExportEngine.export(record_dict=record_dict, export_mimetype="application/vnd.datacite.datacite+json"),
+            record_dict,
+            include_reverse_relations=False,
+        )
         if record_linkset:
             response.headers.update(
                 {

--- a/oarepo_ui/resources/records/resource.py
+++ b/oarepo_ui/resources/records/resource.py
@@ -63,8 +63,7 @@ from invenio_records_resources.services.errors import (
 from invenio_stats.proxies import current_stats
 from invenio_users_resources.proxies import current_user_resources
 from marshmallow import ValidationError
-from oarepo_runtime import current_runtime
-from oarepo_runtime.ext import ExportRepresentation
+from oarepo_runtime.api import ExportEngine, ExportRepresentation
 from oarepo_runtime.typing import record_from_result
 from werkzeug import Response
 from werkzeug.exceptions import Forbidden
@@ -324,6 +323,7 @@ class RecordsUIResource(UIResource[RecordsUIResourceConfig]):
     @pass_route_args("view")
     @pass_query_args("record_detail")
     @pass_record_or_draft(expand=True)
+    @ExportEngine.with_export_cache
     @record_content_negotiation
     @pass_record_files
     @pass_record_media_files
@@ -508,7 +508,7 @@ class RecordsUIResource(UIResource[RecordsUIResourceConfig]):
     ) -> tuple[Any, int, dict[str, str]]:
         """Export page view."""
         try:
-            return current_runtime.get_export_from_serialized_record(  # type: ignore[no-any-return]
+            return ExportEngine.export(  # type: ignore[no-any-return]
                 record_dict=record.to_dict(),
                 representation=ExportRepresentation.RESPONSE,
                 export_code=export_format.lower(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "jinjax>=0.60,<1.0.0",
     "deepmerge>=2.0",
     "python-dotenv>=1.1.1",
-    "oarepo-runtime>=4.0.0,<5.0.0",
+    "oarepo-runtime>=4.5.0,<5.0.0",
     "oarepo-theme>=3.0.0,<4.0.0",
 
     # invenio dependencies


### PR DESCRIPTION
Use ExportEngine cache context to optimize export caching in record_detail.