### PR TITLE
fix: nested errors fix

### DIFF
--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/NestedErrors/NestedErrors.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/NestedErrors/NestedErrors.jsx
@@ -4,6 +4,7 @@ import { Label } from "semantic-ui-react";
 import { useFieldData } from "../../hooks";
 import PropTypes from "prop-types";
 import { collectNestedErrors } from "../../../util";
+import _isEqual from "lodash/isEqual";
 
 // getfielddata must only be called on top level of component because it uses useMemo
 const ErrorMessageItem = ({ error }) => {
@@ -18,9 +19,15 @@ const ErrorMessageItem = ({ error }) => {
 };
 
 export const NestedErrors = ({ fieldPath }) => {
-  const { errors } = useFormikContext();
+  const { errors, initialErrors, values, initialValues } = useFormikContext();
 
-  const fieldErrors = getIn(errors, fieldPath);
+  const liveError = getIn(errors, fieldPath);
+  const untouched = _isEqual(
+    getIn(values, fieldPath),
+    getIn(initialValues, fieldPath)
+  );
+  const fieldErrors =
+    liveError ?? (untouched ? getIn(initialErrors, fieldPath) : undefined);
 
   const nestedErrors = fieldErrors
     ? collectNestedErrors(fieldErrors, fieldPath)

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/util.js
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/util.js
@@ -292,7 +292,10 @@ export function flattenToPathValueArray(obj, prefix = "", res = []) {
       const newKey = prefix ? `${prefix}.${key}` : key;
       flattenToPathValueArray(value, newKey, res);
     });
-  } else {
+  } else if (obj !== undefined) {
+    // Skip undefined leaves: lodash's `_forOwn` iterates arrays from 0 to length-1,
+    // so a sparse hole (e.g. from `_set(obj, "a.1.b", "x")` leaving index 0 unset)
+    // reads as `undefined` and would otherwise emit a phantom entry.
     res.push({ fieldPath: prefix, value: obj });
   }
   return res;

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/util.test.js
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/util.test.js
@@ -315,6 +315,28 @@ describe("flattenToPathValueArray", () => {
       const result = flattenToPathValueArray(errors);
       expect(result).toEqual([{ fieldPath: "files.enabled", value: false }]);
     });
+
+    it("skips sparse-array holes produced by deserializing indexed error paths", () => {
+      // Simulates the shape produced by `_.set({}, "metadata.creators.0.person_or_org.identifiers.1.scheme", "Invalid scheme.")`.
+      // Index 0 of `identifiers` is a sparse hole; lodash's `_forOwn` would read it
+      // as `undefined`, but we should not emit a phantom entry for it.
+      const identifiers = [];
+      identifiers[1] = { scheme: "Invalid scheme." };
+      const errors = {
+        metadata: {
+          creators: [{ person_or_org: { identifiers } }],
+        },
+      };
+
+      const result = flattenToPathValueArray(errors);
+
+      expect(result).toEqual([
+        {
+          fieldPath: "metadata.creators.0.person_or_org.identifiers.1.scheme",
+          value: "Invalid scheme.",
+        },
+      ]);
+    });
   });
 });
 


### PR DESCRIPTION
Now that we have switched to almost all invenio components i.e. deposit bootstra, the error behavior has changed meaning, once you add any field, it ejects everything from formik errors and only initialErrors remain....

This fix basically does in spirit how they do it. 