### PR TITLE
[breaking] fix: spacing between inputs

### DIFF
--- a/oarepo_ui/theme/assets/semantic-ui/less/oarepo_ui/themes/rdm/collections/form.overrides
+++ b/oarepo_ui/theme/assets/semantic-ui/less/oarepo_ui/themes/rdm/collections/form.overrides
@@ -29,6 +29,18 @@
         margin-bottom: 0 !important;
       }
     }
+
+    // When a helptext label sits immediately after a field (helptext rendered
+    // outside the .field, as in Invenio-inherited fields), drop the field's
+    // bottom margin so the helptext doesn't get pushed far below the input.
+    .field:has(+ label.helptext) {
+      margin-bottom: 0 !important;
+    }
+
+    // Cancel the field label's own bottom margin too when helptext follows it.
+    label:not(.helptext):has(+ label.helptext) {
+      margin-bottom: 0 !important;
+    }
   }
   // Desktop vertical tabs (left sidebar)
   .form-tabs-column {
@@ -101,7 +113,15 @@
 
     label.helptext {
       margin-top: 0.5rem;
-      margin-bottom: 1rem;
+      margin-bottom: @fieldMarginBottom;
+    }
+
+    // When helptext sits directly under the field's own label (no input between),
+    // collapse the gap so they read as a unit. Lives inside .ui.segment.tab-content
+    // to match the specificity of the rule above.
+    label:not(.helptext) + label.helptext {
+      margin-top: 0;
+      margin-bottom: 0 !important;
     }
     // these are invenio styles, that are in their case tied to the accordion, but in our case
     // we don't have accordion fields, so had to paste it here

--- a/oarepo_ui/theme/assets/semantic-ui/less/oarepo_ui/themes/rdm/collections/form.variables
+++ b/oarepo_ui/theme/assets/semantic-ui/less/oarepo_ui/themes/rdm/collections/form.variables
@@ -15,7 +15,7 @@
 @activeStepTextColor: @white;
 @stepTextColor: @black;
 @tabContentNavigationMarginTop: 1rem;
-@fieldMarginBottom: 1rem;
+@fieldMarginBottom: 2rem;
 
 // Section completion bar
 @sectionCompletionBarHeight: 3px;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oarepo-ui"
-version = "10.2.0"
+version = "11.0.0"
 description = "UI module for invenio 3.5+"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Unfortunately, as some inputs we inherit from invenio, and helptext is solved in a different say i.e. markup looks entirely different (where labe.helptext is placed), need to resort to some slightly unconventional css.