### PR TITLE
Major version bump due to major bump in packages: invenio-communities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oarepo-ui"
-version = "11.0.0"
+version = "12.0.0"
 description = "UI module for invenio 3.5+"
 readme = "README.md"
 license = "MIT"
@@ -11,8 +11,8 @@ dependencies = [
     "jinjax>=0.60,<1.0.0",
     "deepmerge>=2.0",
     "python-dotenv>=1.1.1",
-    "oarepo-runtime>=5.0.0,<6.0.0",
-    "oarepo-theme>=4.0.0,<5.0.0",
+    "oarepo-runtime>=6.0.0,<7.0.0",
+    "oarepo-theme>=5.0.0,<6.0.0",
 
     # invenio dependencies
     "invenio-app-rdm>=14.0.0b0,<15.0.0",
@@ -31,12 +31,12 @@ dev = [
 ]
 tests = [
     "pytest>=7.1.2",
-    "oarepo-model>=3.0.0,<4.0.0",
-    "pytest-oarepo>=5.0.0,<6.0.0",
+    "oarepo-model>=4.0.0,<5.0.0",
+    "pytest-oarepo>=6.0.0,<7.0.0",
 
     # invenio dependencies
     "invenio-app>=3.0.0,<4.0.0",
-    "invenio-communities>=27.0.0,<28.0.0",
+    "invenio-communities>=28.0.0,<29.0.0",
     "invenio-search>=3.0.0,<4.0.0",
     "pytest-invenio>=4.0.0,<5.0.0",
 ]


### PR DESCRIPTION
Major version bump due to major bump in packages: invenio-communities, pytest-oarepo, oarepo-runtime, oarepo-theme, oarepo-model.
