### PR TITLE
Major version bump due to major bump in packages: invenio-rdm-records

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oarepo-ui"
-version = "12.1.0"
+version = "13.0.0"
 description = "UI module for invenio 3.5+"
 readme = "README.md"
 license = "MIT"
@@ -11,8 +11,8 @@ dependencies = [
     "jinjax>=0.64,<1.0.0",
     "deepmerge>=2.0",
     "python-dotenv>=1.1.1",
-    "oarepo-runtime>=6.0.0,<7.0.0",
-    "oarepo-theme>=5.0.0,<6.0.0",
+    "oarepo-runtime>=7.0.0,<8.0.0",
+    "oarepo-theme>=6.0.0,<7.0.0",
 
     # invenio dependencies
     "invenio-app-rdm>=14.0.0b0,<15.0.0",
@@ -31,7 +31,7 @@ dev = [
 ]
 tests = [
     "pytest>=7.1.2",
-    "oarepo-model>=4.0.0,<5.0.0",
+    "oarepo-model>=5.0.0,<6.0.0",
     "pytest-oarepo>=6.0.0,<7.0.0",
 
     # invenio dependencies


### PR DESCRIPTION
Major version bump due to major bump in packages: oarepo-runtime, oarepo-model, oarepo-theme.
