### PR TITLE
BE-1102: remove delete_draft from deposit create permissions

### DIFF
--- a/oarepo_ui/resources/records/config.py
+++ b/oarepo_ui/resources/records/config.py
@@ -238,7 +238,6 @@ class RecordsUIResourceConfig(UIResourceConfig):
     deposit_create_permissions: ClassVar[list[str]] = [
         "manage",
         "manage_files",
-        "delete_draft",
         "manage_record_access",
     ]
     """List of permission actions to check for deposit create page."""

--- a/tests/test_deposit_create.py
+++ b/tests/test_deposit_create.py
@@ -39,7 +39,6 @@ def test_deposit_create(app, logged_client, users, extra_entry_points):
         }
 
         expected_permissions = {
-            "can_delete_draft": True,
             "can_manage": True,
             "can_manage_files": True,
             "can_manage_record_access": True,


### PR DESCRIPTION
## Summary

Upstream fix for BE-1102: the new-record deposit page (/uploads/new) no longer advertises the `delete_draft` permission, because there is no record to delete yet. The Delete button remains available on the edit deposit page for real drafts.

## Changes

- `oarepo_ui/resources/records/config.py`: removed `delete_draft` from `deposit_create_permissions` (kept in `deposit_edit_permissions`).
- `tests/test_deposit_create.py`: updated the create-page permission expectation to no longer include `can_delete_draft`.

## Verification

- `./run.sh lint` passed (ruff, mypy, pyright).
- `./run.sh jslint` passed (`TabForm.jsx` is clean; one pre-existing warning in `ActiveFilters.jsx`).
- `TabForm.jsx` already guards `DeleteButton` with `permissions?.can_delete_draft && record?.id` — no change needed.
- `resource.py` already passes `dashboard_routes` to form config in both `_create()` and `_edit()` — no change needed.
