### PR TITLE
unified permissions

### DIFF
--- a/oarepo_ui/config.py
+++ b/oarepo_ui/config.py
@@ -69,19 +69,14 @@ OAREPO_UI_RECORD_ACTIONS = {
     "manage_files",
     "manage_record_access",
     "publish",
-}
-
-OAREPO_UI_DRAFT_ACTIONS = {
-    "read_draft": "read",
-    "update_draft": "update",
-    "delete_draft": "delete",
-    "draft_read_files": "read_files",
-    "draft_update_files": "update_files",
-    "draft_read_deleted_files": "read_deleted_files",
-    "manage": "manage",  # add manage to draft actions - it is the same for drafts as well as published
-    "manage_files": "manage_files",
-    "manage_record_access": "manage_record_access",
-    "publish": "publish",
+    "read_draft",
+    "update_draft",
+    "delete_draft",
+    "draft_read_files",
+    "draft_update_files",
+    "draft_read_deleted_files",
+    "media_read_files",
+    "moderate",
 }
 
 OAREPO_UI_OVERRIDES: set[UIComponentOverride] = set()

--- a/oarepo_ui/ext.py
+++ b/oarepo_ui/ext.py
@@ -113,23 +113,15 @@ class OARepoUIState:
     def record_actions(self) -> dict[str, str]:
         """Get the mapping of api permissions (actions) to UI permission flags.
 
-        This is normally an identity for the published record actions, but can be
-        used to map to custom actions.
+        Single global set covering both published-record and draft actions; each
+        action name maps to itself (e.g. ``delete_draft`` and ``delete`` are
+        distinct actions, kept as distinct ``can_*`` flags).
         """
         ret = self.app.config["OAREPO_UI_RECORD_ACTIONS"]
         if not isinstance(ret, dict):
             # convert to dict with action name as key and action name as value
             ret = {action: action for action in ret}
         return ret
-
-    @cached_property
-    def draft_actions(self) -> dict[str, str]:
-        """Get the mapping of api permissions (actions) to UI permission flags for drafts.
-
-        This maps the actions that are available for drafts, such as delete_draft,
-        to the same ui permission flags as the published record actions (delete in this case).
-        """
-        return cast("dict[str, str]", self.app.config["OAREPO_UI_DRAFT_ACTIONS"])
 
     @cached_property
     def ui_overrides(self) -> set[UIComponentOverride]:

--- a/oarepo_ui/resources/components/base.py
+++ b/oarepo_ui/resources/components/base.py
@@ -68,7 +68,7 @@ class UIResourceComponent[T: UIResourceConfig = UIResourceConfig]:
         :param context: the context dictionary that will be merged into the template's context
         """
 
-    def before_ui_detail(
+    def before_ui_detail(  # noqa: PLR0913  too many arguments
         self,
         *,
         api_record: RecordItem,
@@ -76,6 +76,7 @@ class UIResourceComponent[T: UIResourceConfig = UIResourceConfig]:
         identity: Identity,
         ui_links: dict,
         extra_context: dict,
+        render_kwargs: dict,
         **kwargs: Any,
     ) -> None:
         """Process the data before the detail page is rendered.
@@ -85,7 +86,7 @@ class UIResourceComponent[T: UIResourceConfig = UIResourceConfig]:
         :param identity: the current user identity
         :param ui_links: UI links for the record, a dictionary of link name -> link url
         :param extra_context: will be passed to the template as the "extra_context" variable
-        :param kwargs: additional keyword arguments, including render_kwargs with record_ui, is_preview, is_draft
+        :param render_kwargs: dictionary of render kwargs (mutable) passed to the template
         """
 
     def before_ui_search(
@@ -144,6 +145,7 @@ class UIResourceComponent[T: UIResourceConfig = UIResourceConfig]:
         form_config: dict,
         ui_links: dict,
         extra_context: dict,
+        render_kwargs: dict,
         **kwargs: Any,
     ) -> None:
         """Process the data before the edit page is rendered.
@@ -156,13 +158,12 @@ class UIResourceComponent[T: UIResourceConfig = UIResourceConfig]:
                         template to display, for example, the localized record title.
         :param identity: the current user identity
         :param form_config: form configuration dictionary
-        :param args: query parameters
-        :param view_args: view arguments
         :param ui_links: UI links for the edit page, a dictionary of link name -> link url
         :param extra_context: will be passed to the template as the "extra_context" variable
+        :param render_kwargs: dictionary of render kwargs (mutable) passed to the template
         """
 
-    def before_ui_create(
+    def before_ui_create(  # noqa: PLR0913  too many arguments
         self,
         *,
         data: dict,
@@ -170,6 +171,7 @@ class UIResourceComponent[T: UIResourceConfig = UIResourceConfig]:
         form_config: dict,
         ui_links: dict,
         extra_context: dict,
+        render_kwargs: dict,
         **kwargs: Any,
     ) -> None:
         """Process the data before the create page is rendered.
@@ -179,8 +181,7 @@ class UIResourceComponent[T: UIResourceConfig = UIResourceConfig]:
         :param data: A dictionary with empty data (show just the structure of the record, with values replaced by None)
         :param identity: the current user identity
         :param form_config: form configuration dictionary
-        :param args: query parameters
-        :param view_args: view arguments
         :param ui_links: UI links for the create page, a dictionary of link name -> link url
         :param extra_context: will be passed to the template as the "extra_context" variable
+        :param render_kwargs: dictionary of render kwargs (mutable) passed to the template
         """

--- a/oarepo_ui/resources/components/permissions.py
+++ b/oarepo_ui/resources/components/permissions.py
@@ -8,8 +8,10 @@
 #
 """Component that exposes record-related permissions to templates and forms.
 
-Populates extra_context and form configuration with boolean flags indicating
-which record actions are allowed for the current identity and record state.
+Populates extra_context, render_kwargs and search options with boolean flags
+indicating which record actions are allowed for the current identity and record
+state. A single global action set is used for both drafts and published records
+so the resulting ``can_*`` dict has the same shape everywhere.
 """
 
 from __future__ import annotations
@@ -46,15 +48,12 @@ class PermissionsComponent[T: RecordsUIResourceConfig = RecordsUIResourceConfig]
         api_record: RecordItem,
         identity: Identity,
         extra_context: dict[str, Any],
+        render_kwargs: dict[str, Any],
         **kwargs: Any,
     ) -> None:
-        """Attach permissions before rendering the detail page.
-
-        :param api_record: RecordItem wrapper around the record being displayed.
-        :param extra_context: Context dict to be passed to the template.
-        :param identity: Current user identity.
-        """
+        """Attach permissions before rendering the detail page."""
         self.fill_permissions(self._get_underlying_record(api_record), extra_context, identity)
+        render_kwargs["permissions"] = extra_context["permissions"]
 
     @override
     def before_ui_edit(
@@ -63,15 +62,12 @@ class PermissionsComponent[T: RecordsUIResourceConfig = RecordsUIResourceConfig]
         api_record: RecordItem,
         identity: Identity,
         extra_context: dict[str, Any],
+        render_kwargs: dict[str, Any],
         **kwargs: Any,
     ) -> None:
-        """Attach permissions before rendering the edit page.
-
-        :param api_record: RecordItem wrapper around the record being edited.
-        :param extra_context: Context dict to be passed to the template.
-        :param identity: Current user identity.
-        """
+        """Attach permissions before rendering the edit page."""
         self.fill_permissions(self._get_underlying_record(api_record), extra_context, identity)
+        render_kwargs["permissions"] = extra_context["permissions"]
 
     @override
     def before_ui_create(
@@ -79,14 +75,12 @@ class PermissionsComponent[T: RecordsUIResourceConfig = RecordsUIResourceConfig]
         *,
         identity: Identity,
         extra_context: dict[str, Any],
+        render_kwargs: dict[str, Any],
         **kwargs: Any,
     ) -> None:
-        """Attach permissions for creating a new record.
-
-        :param extra_context: Context dict to be passed to the template.
-        :param identity: Current user identity.
-        """
+        """Attach permissions for creating a new record."""
         self.fill_permissions(None, extra_context, identity)
+        render_kwargs["permissions"] = extra_context["permissions"]
 
     @override
     def before_ui_search(
@@ -97,12 +91,7 @@ class PermissionsComponent[T: RecordsUIResourceConfig = RecordsUIResourceConfig]
         search_options: dict[str, Any],
         **kwargs: Any,
     ) -> None:
-        """Attach permissions for the search page and propagate to search options.
-
-        :param extra_context: Context dict to be passed to the template.
-        :param identity: Current user identity.
-        :param search_options: Dict with search configuration; overrides will be mutated.
-        """
+        """Attach permissions for the search page and propagate to search options."""
         from ..records.resource import RecordsUIResource
 
         if not isinstance(self.resource, RecordsUIResource):
@@ -111,23 +100,6 @@ class PermissionsComponent[T: RecordsUIResourceConfig = RecordsUIResourceConfig]
         extra_context["permissions"] = {"can_create": self.resource.has_deposit_permissions(identity)}
         # fixes issue with permissions not propagating down to template
         search_options["overrides"]["permissions"] = extra_context["permissions"]
-
-    @override
-    def form_config(
-        self,
-        *,
-        form_config: dict[str, Any],
-        api_record: RecordItem | None = None,
-        identity: Identity,
-        **kwargs: Any,
-    ) -> None:
-        """Add permissions to the form configuration for create/edit pages.
-
-        :param form_config: Form configuration dictionary to mutate in-place.
-        :param api_record: RecordItem if editing, or None if creating.
-        :param identity: Current user identity.
-        """
-        self.fill_permissions(self._get_underlying_record(api_record), form_config, identity)
 
     def get_record_permissions(
         self,
@@ -144,7 +116,6 @@ class PermissionsComponent[T: RecordsUIResourceConfig = RecordsUIResourceConfig]
         :param identity: Current user identity.
         :param record: Underlying record or draft, or empty dict if not present.
         :returns: A dict of permission flags, e.g. {"can_read": True}.
-        :raises: None (permission check errors are handled defensively)
         """
         ret: dict[str, bool] = {}
         for action_name, mapped_to in actions.items():
@@ -162,33 +133,17 @@ class PermissionsComponent[T: RecordsUIResourceConfig = RecordsUIResourceConfig]
         identity: Identity,
         **kwargs: Any,
     ) -> None:
-        """Populate extra_context or form_config with permission flags.
-
-        :param record: The record/draft or None when creating a new record.
-        :param extra_context: Dict to be updated with a "permissions" mapping.
-        :param identity: Current user identity.
-        :returns: None
-        :raises: None
-        """
+        """Populate extra_context with permission flags using the single global action set."""
         from ..records.resource import RecordsUIResource
 
         if not isinstance(self.resource, RecordsUIResource):
             return
 
-        # prefill permissions with False (drafts do not have some of those)
-        extra_context["permissions"] = {
-            f"can_{mapped_to}": False for _action, mapped_to in current_oarepo_ui.record_actions.items()
-        }
-        extra_context["permissions"].update(
-            self.get_record_permissions(
-                (
-                    current_oarepo_ui.draft_actions
-                    if record and getattr(record, "is_draft", False)
-                    else current_oarepo_ui.record_actions
-                ),
-                self.resource.api_service,
-                identity,
-                record,
-                **kwargs,
-            )
+        actions = current_oarepo_ui.record_actions
+        extra_context["permissions"] = self.get_record_permissions(
+            actions,
+            self.resource.api_service,
+            identity,
+            record,
+            **kwargs,
         )

--- a/oarepo_ui/resources/records/config.py
+++ b/oarepo_ui/resources/records/config.py
@@ -11,7 +11,7 @@
 from __future__ import annotations
 
 import inspect
-from typing import TYPE_CHECKING, Any, ClassVar, NotRequired, TypedDict, cast
+from typing import TYPE_CHECKING, Any, NotRequired, TypedDict, cast
 
 import marshmallow as ma
 from flask import current_app
@@ -212,36 +212,6 @@ class RecordsUIResourceConfig(UIResourceConfig):
     field_data_item_getter: FieldDataItemGetter | None = None
     """Field data item getter for retrieving field data items in the UI.
     If not set, the default getter will be used."""
-
-    record_detail_permissions: ClassVar[list[str]] = [
-        "edit",
-        "new_version",
-        "manage",
-        "update_draft",
-        "read_files",
-        "review",
-        "view",
-        "media_read_files",
-        "moderate",
-    ]
-    """List of permission actions to check for record detail page."""
-
-    deposit_edit_permissions: ClassVar[list[str]] = [
-        "manage",
-        "new_version",
-        "delete_draft",
-        "manage_files",
-        "manage_record_access",
-    ]
-    """List of permission actions to check for deposit edit page."""
-
-    deposit_create_permissions: ClassVar[list[str]] = [
-        "manage",
-        "manage_files",
-        "delete_draft",
-        "manage_record_access",
-    ]
-    """List of permission actions to check for deposit create page."""
 
     @property
     def ui_links_item(self) -> Mapping[str, EndpointLink]:

--- a/oarepo_ui/resources/records/resource.py
+++ b/oarepo_ui/resources/records/resource.py
@@ -269,7 +269,6 @@ class RecordsUIResource(UIResource[RecordsUIResourceConfig]):
             "files": files_dict,
             "media_files": media_files_dict,
             "user_communities_memberships": get_user_communities_memberships(),
-            "permissions": (record.has_permissions_to(self.config.record_detail_permissions) if record else {}),
             # TODO: implement custom fields
             "is_preview": is_preview,
             "include_deleted": include_deleted,
@@ -588,7 +587,6 @@ class RecordsUIResource(UIResource[RecordsUIResourceConfig]):
                 "searchUrl": url_for(f"{self.config.blueprint_name}.search"),
             },
             "files_locked": files_locked,
-            "permissions": draft.has_permissions_to(self.config.deposit_edit_permissions),
             # TODO: implement record deletion
             "extra_context": extra_context,
             "ui_links": ui_links,
@@ -665,11 +663,6 @@ class RecordsUIResource(UIResource[RecordsUIResourceConfig]):
     def _get_form_config(self, identity: Identity, **kwargs: Any) -> dict[str, Any]:
         return self.config.form_config(identity=identity, **kwargs)
 
-    def get_record_permissions(self, actions: list[str], record: Record | None = None) -> dict[str, bool]:
-        """Generate (default) record action permissions."""
-        service = self.api_service
-        return {f"can_{action}": service.check_permission(g.identity, action, record=record) for action in actions}
-
     def _create(
         self,
         community: str | None = None,
@@ -737,7 +730,6 @@ class RecordsUIResource(UIResource[RecordsUIResourceConfig]):
             "ui_links": ui_links,
             "webpack_entry": f"{self.config.model_name}_deposit_form.js",
             "context": current_oarepo_ui.catalog.jinja_env.globals,
-            "permissions": self.get_record_permissions(self.config.deposit_create_permissions),
             "model_name": self.config.model_name,
         }
 

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/DepositFormApp/DepositFormApp.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/DepositFormApp/DepositFormApp.jsx
@@ -94,7 +94,7 @@ export class DepositFormApp extends Component {
       apiClient: apiClient,
       fileApiClient: fileApiClient,
       service: service,
-      permissions: props.config.permissions,
+      permissions: props.permissions,
       recordSerializer: recordSerializer,
     };
 

--- a/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/TabForm/TabForm.jsx
+++ b/oarepo_ui/theme/assets/semantic-ui/js/oarepo_ui/forms/components/TabForm/TabForm.jsx
@@ -50,6 +50,7 @@ export const TabForm = ({ sections = [] }) => {
   const formik = useFormikContext();
   const { dirty, values } = formik;
   const reduxState = useSelector((state) => state);
+
   const params = new URLSearchParams(window.location.search);
   const initialTabKey = params.get("tab");
   const initialStep = sectionKeys.indexOf(initialTabKey);

--- a/tests/test_ui_resource_config.py
+++ b/tests/test_ui_resource_config.py
@@ -40,7 +40,6 @@ def test_ui_resource_form_config(app, simple_model_ui_resource_config, simple_mo
         ui_links=simple_model_ui_resource_config.ui_links_search,
     )
 
-    assert "permissions" in fc
     assert "custom_fields" in fc
 
 


### PR DESCRIPTION
We had permissions being checked in different ways. Something was in config variables, something was in ui resource/config. IMHO, also no reason to differentiate between drafts/records permissions because appropriate service handles those and must return correct values. Made a unification, so that permissions would behave the same. Especially important for the form, where it was rather confusing.