### PR TITLE
fix: app-hanging-on-restricted-record-access-when-not-logged-in

### DIFF
--- a/oarepo_ui/resources/records/resource.py
+++ b/oarepo_ui/resources/records/resource.py
@@ -938,7 +938,7 @@ class RecordsUIResource(UIResource[RecordsUIResourceConfig]):
         """Handle permission denied error on record views."""
         if not current_user.is_authenticated:
             # trigger the flask-login unauthorized handler
-            return Response(current_app.login_manager.unauthorized())  # type: ignore[attr-defined]
+            return current_app.login_manager.unauthorized()  # type: ignore[attr-defined,no-any-return]
 
         record = getattr(error, "record", None)
         if record:


### PR DESCRIPTION
⏺ Update(oarepo_ui/resources/records/resource.py)
    File "/Users/dusanstojanovic/Projects/datarepo/.venv/lib/python3.14/site-packages/werkzeug/wsgi.py", line 270, in __next__                     
      return self._next()                                                                                                                          
             ~~~~~~~~~~^^                                                                                                                          
    File "/Users/dusanstojanovic/Projects/datarepo/.venv/lib/python3.14/site-packages/werkzeug/wrappers/response.py", line 32, in _iter_encoded    
      for item in iterable:                                                                                                                        
                  ^^^^^^^^                                                                                                                         
  TypeError: 'Response' object is not iterable         
  
  We are wrapping response in response and it fails fixes issue https://datarepo.eosc.cz/datasets/records/datst.y78mf-f0y22 