### PR TITLE
feat: register APP_RDM_PAGES static page routes in UI blueprint

### DIFF
--- a/oarepo_ui/views.py
+++ b/oarepo_ui/views.py
@@ -23,6 +23,7 @@ from flask import (
 )
 from flask_menu import current_menu
 from invenio_app_rdm.theme.views import (
+    add_static_page_routes,
     help_search,
     help_statistics,
     # help_versioning,
@@ -58,6 +59,17 @@ def create_blueprint(app: Flask) -> Blueprint:
         blueprint.add_url_rule(**create_url_rule(routes.get("help_statistics"), default_view_func=help_statistics))
         # TODO: uncomment when we have the proper config in APP_RDM_ROUTES
         # blueprint.add_url_rule(**create_url_rule(routes.get("help_versioning"), default_view_func=help_versioning)) #noqa
+
+    # Register explicit, locale-aware routes for static pages declared in
+    # APP_RDM_PAGES. Upstream invenio-app-rdm does this in its own theme
+    # blueprint, but that blueprint is not registered on this stack, so we
+    # wire it in here to avoid falling back to invenio-pages' broken 404
+    # auto-registration (KeyError: 'invenio_pages.view' on the second request).
+    # `add_static_page_routes` reads app.config["APP_RDM_PAGES"] with an
+    # unguarded subscript, and blueprint creation can run before our
+    # init_config seeds the default, so ensure it exists here at the point of use.
+    app.config.setdefault("APP_RDM_PAGES", {})
+    add_static_page_routes(blueprint, app)
 
     blueprint.app_context_processor(lambda: ({"current_app": app}))
     blueprint.app_context_processor(lambda: ({"now": datetime.datetime.now(tz=datetime.UTC)}))

--- a/oarepo_ui/views.py
+++ b/oarepo_ui/views.py
@@ -66,8 +66,8 @@ def create_blueprint(app: Flask) -> Blueprint:
     # wire it in here to avoid falling back to invenio-pages' broken 404
     # auto-registration (KeyError: 'invenio_pages.view' on the second request).
     # `add_static_page_routes` reads app.config["APP_RDM_PAGES"] with an
-    # unguarded subscript, and blueprint creation can run before our
-    # init_config seeds the default, so ensure it exists here at the point of use.
+    # unguarded subscript, so ensure the key exists here at the point of use
+    # (it may not be set by this extension's init_config).
     app.config.setdefault("APP_RDM_PAGES", {})
     add_static_page_routes(blueprint, app)
 


### PR DESCRIPTION
## What & why

Static pages declared in `APP_RDM_PAGES` (e.g. `/about`, `/basic`) currently do **not** get routes on this stack, so they are effectively broken.

### Root cause
Upstream `invenio-app-rdm` registers static-page routes inside **its own** theme blueprint (`invenio_app_rdm.theme.views:create_blueprint`, via `add_static_page_routes`). On our stack that blueprint is **not** registered under `invenio_base.blueprints` — the only theme/UI blueprint that loads is `oarepo_ui.views:create_blueprint`. As a result:

- `APP_RDM_PAGES` is read by nobody → inert.
- Every static-page URL has no real route → it 404s → `invenio-pages` `handle_not_found` runs its **broken** auto-registration: it adds a URL rule bound to the endpoint `invenio_pages.view`, but no view function is ever registered under that endpoint.
- The **first** request renders inline (200), but the **second** request matches the dangling rule and Flask's dispatch does `view_functions["invenio_pages.view"]` → `KeyError: 'invenio_pages.view'` (HTTP 500).

(The invenio-pages bug is present on `master` and in v10.0.0; the intended removal of dynamic registration from #61 was never completed.)

### Change
Import `add_static_page_routes` from `invenio_app_rdm.theme.views` and call it inside our `create_blueprint`. Since our blueprint is already named `invenio_app_rdm`, the routes land under the expected endpoints and go through `create_page_view` → `render_page` → the locale-aware `read_by_url`.

### Effect
- Pages in `APP_RDM_PAGES` get explicit, locale-aware routes.
- The buggy 404 auto-registration path is no longer hit, so no more `KeyError: 'invenio_pages.view'`.

## Testing
- Configure `APP_RDM_PAGES = {"basic": "/basic"}`, load a `/basic` page via `invenio rdm pages create`, restart, then hit `/basic` and refresh — renders on every request (previously 500'd on refresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)